### PR TITLE
Add msp430 asm tests

### DIFF
--- a/t.asm/msp430/msp430
+++ b/t.asm/msp430/msp430
@@ -13,6 +13,8 @@ EXPECT="${2}
 run_test
 }
 
+BROKEN=1
+
 test_msp430 3041 "ret"
 
 test_msp430 fb903b000000 "cmp.b #0x3b, 0x0(r11)"

--- a/t.asm/msp430/msp430
+++ b/t.asm/msp430/msp430
@@ -1,0 +1,18 @@
+#!/bin/bash
+for a in . .. ../.. ; do [ -e $a/tests.sh ] && . $a/tests.sh ; done
+
+test_msp430() {
+NAME="msp430:${2}"
+FILE=malloc://8
+ARGS="-w -a msp430"
+CMDS='wx'${1}'
+pi 1
+'
+EXPECT="${2}
+"
+run_test
+}
+
+test_msp430 3041 "ret"
+
+test_msp430 fb903b000000 "cmp.b #0x3b, 0x0(r11)"


### PR DESCRIPTION
Both tests currently fail:
1. returns "ret " with an extra space
2. returns "cmp.b #0x003b, 0x3b(r11)" instead of "cmp.b #0x3b, 0x0(r11)" (https://github.com/SaitoYutaka/MSP430-Disassembler seems to handle it correctly)