### PR TITLE
+ broken test for asm labels replacement with common prefix

### DIFF
--- a/files/multiline_prefix.asm
+++ b/files/multiline_prefix.asm
@@ -1,0 +1,5 @@
+label:
+nop
+nop
+labelA:
+call labelA

--- a/t.asm/labels/prefix
+++ b/t.asm/labels/prefix
@@ -1,0 +1,14 @@
+for a in . .. ../.. ../../.. ; do [ -e $a/tests.sh ] && . $a/tests.sh; done
+
+TESTFILE=../../files/multiline_prefix.asm
+NAME='labels replacements (common prefix)'
+BROKEN=1
+FILE=malloc://1024
+ARGS=
+CMDS='e asm.arch=x86
+e asm.bits=32
+waf '"$TESTFILE"'
+p8 7@0'
+EXPECT='9090e8fbffffff
+'
+run_test


### PR DESCRIPTION
when labels has common prefix and different lengths, replacement breaks the code. it may be an issue of  how equs are replaced, i guess they should be replaced in order of length (longer first).