### PR TITLE
fixed mips tests

### DIFF
--- a/t.anal/mips/mips
+++ b/t.anal/mips/mips
@@ -71,20 +71,23 @@ e anal.depth=2
 e asm.cmtcol=0
 e asm.comments=false
 e asm.lines=0
+e asm.fcnlines=0
 e asm.nbytes=4
 wx 0800040c000000000000000000000000000000000000000040040408000000000800e00300000000
 aa 2> /dev/null
 pdf
 "
-EXPECT='/ (fcn) fcn.00000000 32
-| 0x00000000    0800040c   jal 0x100020
-| 0x00000004    00000000   nop
-| 0x00000008    00000000   nop
-| 0x0000000c    00000000   nop
-| 0x00000010    00000000   nop
-| 0x00000014    00000000   nop
-| 0x00000018    40040408   j 0x101100
-\ 0x0000001c    00000000   nop
+EXPECT='(fcn) fcn.00000000 40
+0x00000000    0800040c   jal 0x100020
+0x00000004    00000000   nop
+0x00000008    00000000   nop
+0x0000000c    00000000   nop
+0x00000010    00000000   nop
+0x00000014    00000000   nop
+0x00000018    40040408   j 0x101100
+0x0000001c    00000000   nop
+0x00000020    0800e003   jr ra
+0x00000024    00000000   nop
 '
 run_test
 
@@ -92,7 +95,7 @@ run_test
 # Test that jumps / calls used mapped address if used (Case 2 - mapped)
 #
 NAME="mips LE correct relative jump reference if mapped from command line."
-BROKEN=1
+BROKEN=
 FILE=malloc://40
 ARGS='-m 0x80100000'
 CMDS="e asm.bits=32
@@ -100,25 +103,27 @@ e asm.arch=${PLUGIN}
 e anal.eobjmp=false
 e anal.depth=3
 e asm.lines=0
+e asm.fcnlines=false
 e asm.nbytes=4
 wx 0800040c000000000000000000000000000000000000000040040408000000000800e00300000000
 af 2> /dev/null
 pdf
 afl
 "
-EXPECT='/ (fcn) fcn.80100000 40
-/ (fcn) fcn.80100000 4352
-| 0x80100000    0800040c   jal 0x80100020                               ; (fcn.80100000)
-| 0x80100004    00000000     nop
-| 0x80100008    00000000     nop
-| 0x8010000c    00000000     nop
-| 0x80100010    00000000     nop
-| 0x80100014    00000000     nop
-| 0x80100018    40040408     j 0x80101100
-| 0x8010001c    00000000     nop
-| 0x80100020    0800e003     jr ra
-\ 0x80100024    00000000     nop
-0x80100000  40  1  fcn.80100000
+EXPECT='(fcn) fcn.80100000 40
+; CALL XREF from 0x80100000 (fcn.80100000)
+0x80100000    0800040c   jal 0x80100020                               
+0x80100004    00000000   nop
+0x80100008    00000000   nop
+0x8010000c    00000000   nop
+0x80100010    00000000   nop
+0x80100014    00000000   nop
+0x80100018    40040408   j 0x80101100
+0x8010001c    00000000   nop
+; CALL XREF from 0x80100000 (fcn.80100000)
+0x80100020    0800e003   jr ra
+0x80100024    00000000   nop
+0x80100000  40  2  fcn.80100000
 '
 run_test
 
@@ -134,32 +139,35 @@ CMDS="e asm.bits=32
 e asm.arch=${PLUGIN}
 e anal.depth=2
 e asm.nbytes=4
+e asm.lines=false
+e asm.fcnlines=false
 s 0x80100000
 wx 0800e0030a184400000000000000000000000
 af 2>/dev/null
 pdf
 "
-EXPECT='/ (fcn) fcn.80100000 8
-|           0x80100000    0800e003   jr ra
-\           0x80100004    0a184400   movz v1, v0, a0
+EXPECT='(fcn) fcn.80100000 8
+0x80100000    0800e003   jr ra
+0x80100004    0a184400   movz v1, v0, a0
 '
 run_test
 
 NAME="mips branch delay function sizing."
-BROKEN=1
+BROKEN=
 FILE=malloc://20
 ARGS=
 CMDS="e asm.bits=32
 e asm.arch=${PLUGIN}
 e anal.depth=2
 e asm.nbytes=4
+e asm.fcnlines=false
 wx 0800e0030a184400000000000000000000000
 af 2> /dev/null
 pdf
 "
-EXPECT='/ (fcn) fcn.00000000 8
-|          0x00000000    0800e003     jr ra
-\          0x00000004    0a184400     movz v1, v0, a0
+EXPECT='(fcn) fcn.00000000 8
+          0x00000000    0800e003   jr ra
+          0x00000004    0a184400   movz v1, v0, a0
 '
 run_test
 
@@ -168,7 +176,7 @@ run_test
 # As a hack we skip return on the fail pass if mips, but is the test coverage complete?
 
 NAME="mips branch delay function sizing with conditional jump loop."
-BROKEN=1
+BROKEN=
 FILE=malloc://40
 ARGS='-m 0x80100000'
 CMDS="e asm.bits=32
@@ -177,20 +185,22 @@ e anal.eobjmp=false
 e asm.comments=false
 e anal.depth=2
 e asm.nbytes=4
+e asm.lines=false
+e asm.fcnlines=false
 s 0x80100000
 wx e0ffbd27000000000100001000000000fdff09150a1844000800e0032000bd27000000000000000000000
 af 2> /dev/null
 pdf
 "
-EXPECT='/ (fcn) fcn.80100000 32
-|          0x80100000    e0ffbd27   addiu sp, sp, -0x20
-|          0x80100004    00000000   nop
-|     .,=< 0x80100008    01000010   b 0x80100010
-|     ||   0x8010000c    00000000   nop
-|     ``-> 0x80100010    fdff0915   bne t0, t1, 0x80100008
-|          0x80100014    0a184400   movz v1, v0, a0
-|          0x80100018    0800e003   jr ra
-\          0x8010001c    2000bd27   addiu sp, sp, 0x20
+EXPECT='(fcn) fcn.80100000 32
+0x80100000    e0ffbd27   addiu sp, sp, -0x20
+0x80100004    00000000   nop
+0x80100008    01000010   b 0x80100010
+0x8010000c    00000000   nop
+0x80100010    fdff0915   bne t0, t1, 0x80100008
+0x80100014    0a184400   movz v1, v0, a0
+0x80100018    0800e003   jr ra
+0x8010001c    2000bd27   addiu sp, sp, 0x20
 '
 run_test
 
@@ -205,25 +215,27 @@ e anal.eobjmp=false
 e anal.nopskip=false
 e anal.depth=2
 e asm.nbytes=4
+e asm.lines=false
+e asm.fcnlines=false
 s 0x80100000
 wx e0ffbd27000000000100001000000000000000000a1844000800e003 2000bd27000000000000000000000
 af 2> /dev/null
 pdf
 "
-EXPECT='/ (fcn) fcn.80100000 32
-|           0x80100000    e0ffbd27   addiu sp, sp, -0x20
-|           0x80100004    00000000   nop
-|       ,=< 0x80100008    01000010   b 0x80100010
-|       |   0x8010000c    00000000   nop
-|       `-> 0x80100010    00000000   nop
-|           0x80100014    0a184400   movz v1, v0, a0
-|           0x80100018    0800e003   jr ra
-\           0x8010001c    2000bd27   addiu sp, sp, 0x20
+EXPECT='(fcn) fcn.80100000 32
+0x80100000    e0ffbd27   addiu sp, sp, -0x20
+0x80100004    00000000   nop
+0x80100008    01000010   b 0x80100010
+0x8010000c    00000000   nop
+0x80100010    00000000   nop
+0x80100014    0a184400   movz v1, v0, a0
+0x80100018    0800e003   jr ra
+0x8010001c    2000bd27   addiu sp, sp, 0x20
 '
 run_test
 
 NAME="mips branch delay function sizing with conditional jump back."
-BROKEN=1
+BROKEN=
 FILE=malloc://40
 ARGS='-m 0x80100000'
 CMDS="e asm.arch=${PLUGIN}
@@ -233,24 +245,26 @@ e anal.eobjmp=false
 e anal.nopskip=false
 e anal.depth=2
 e asm.nbytes=4
+e asm.lines=false
+e asm.fcnlines=false
 wx e0ffbd27000000000000000000000000fdff09150a1844000800e0032000bd27000000000000000000000
 af 2> /dev/null
 pdf
 "
-EXPECT='/ (fcn) fcn.80100000 32
-|          0x80100000    e0ffbd27     addiu sp, sp, -0x20
-|          0x80100004    00000000     nop
-|      .-> 0x80100008    00000000     nop
-|      |   0x8010000c    00000000     nop
-|      `=< 0x80100010    fdff0915     bne t0, t1, 0x80100008
-|          0x80100014    0a184400     movz v1, v0, a0
-|          0x80100018    0800e003     jr ra
-\          0x8010001c    2000bd27     addiu sp, sp, 0x20
+EXPECT='(fcn) fcn.80100000 32
+0x80100000    e0ffbd27   addiu sp, sp, -0x20
+0x80100004    00000000   nop
+0x80100008    00000000   nop
+0x8010000c    00000000   nop
+0x80100010    fdff0915   bne t0, t1, 0x80100008
+0x80100014    0a184400   movz v1, v0, a0
+0x80100018    0800e003   jr ra
+0x8010001c    2000bd27   addiu sp, sp, 0x20
 '
 run_test
 
 NAME="mips branch delay function sizing with conditional jump back then forward."
-BROKEN=1
+BROKEN=
 FILE=malloc://56
 ARGS='-m 0x80100000'
 CMDS="e asm.arch=${PLUGIN}
@@ -260,22 +274,24 @@ e anal.eobjmp=false
 e anal.nopskip=false
 e anal.depth=2
 e asm.nbytes=4
+e asm.lines=false
+e asm.fcnlines=false
 wx e0ffbd27000000000000000000000000fdff09150000000001000010000000000a1844000800e0032000bd27000000000000000000000
 af 2> /dev/null
 pdf
 "
-EXPECT='/ (fcn) fcn.80100000 44
-|          0x80100000    e0ffbd27   addiu sp, sp, -0x20
-|          0x80100004    00000000   nop
-|      .-> 0x80100008    00000000   nop
-|      |   0x8010000c    00000000   nop
-|      `=< 0x80100010    fdff0915   bne t0, t1, 0x80100008
-|          0x80100014    00000000   nop
-|     ,==< 0x80100018    01000010   b 0x80100020
-|     |    0x8010001c    00000000   nop
-|     `--> 0x80100020    0a184400   movz v1, v0, a0
-|          0x80100024    0800e003   jr ra
-\          0x80100028    2000bd27   addiu sp, sp, 0x20
+EXPECT='(fcn) fcn.80100000 44
+0x80100000    e0ffbd27   addiu sp, sp, -0x20
+0x80100004    00000000   nop
+0x80100008    00000000   nop
+0x8010000c    00000000   nop
+0x80100010    fdff0915   bne t0, t1, 0x80100008
+0x80100014    00000000   nop
+0x80100018    01000010   b 0x80100020
+0x8010001c    00000000   nop
+0x80100020    0a184400   movz v1, v0, a0
+0x80100024    0800e003   jr ra
+0x80100028    2000bd27   addiu sp, sp, 0x20
 '
 run_test
 
@@ -290,54 +306,59 @@ e anal.eobjmp=0
 e anal.nopskip=1
 e anal.depth=2
 e asm.nbytes=4
+e asm.lines=false
+e asm.fcnlines=false
 s 0x8060b4f8
 wx 0000000000000000002e0500032e05000f00801021100000492d1808000082900800e003211080000000829007004010000000000016020003160200f8ff451000000000482d180801008424211000000800e003000000000000a290050040100100a524000082a00000a290552d1808010084240800e003000080a000000000e0ffbd27542d180c000000000800e0032000bd270000000000000000
 aa 2> /dev/null
 pd 38
 "
-EXPECT='            0x8060b4f8    00000000   nop
-            0x8060b4fc    00000000   nop
-/ (fcn) fcn.8060b500 80
-|           0x8060b500    002e0500   sll a1, a1, 0x18
-|           0x8060b504    032e0500   sra a1, a1, 0x18
-|       ,=< 0x8060b508    0f008010   beqz a0, 0x8060b548
-|       |   0x8060b50c    21100000   move v0, zero
-|      ,==< 0x8060b510    492d1808   j 0x8060b524
-|      ||   0x8060b514    00008290   lbu v0, 0(a0)
-|     .---> 0x8060b518    0800e003   jr ra
-|     |||   0x8060b51c    21108000   move v0, a0
-|    .----> 0x8060b520    00008290   lbu v0, 0(a0)
-|   ,==`--> 0x8060b524    07004010   beqz v0, 0x8060b544
-|   ||| |   0x8060b528    00000000   nop
-|   ||| |   0x8060b52c    00160200   sll v0, v0, 0x18
-|   ||| |   0x8060b530    03160200   sra v0, v0, 0x18
-|   ||`===< 0x8060b534    f8ff4510   beq v0, a1, 0x8060b518
-|   ||  |   0x8060b538    00000000   nop
-|   |`====< 0x8060b53c    482d1808   j 0x8060b520
-|   |   |   0x8060b540    01008424   addiu a0, a0, 1
-|   `-----> 0x8060b544    21100000   move v0, zero
-|       `-> 0x8060b548    0800e003   jr ra
-\           0x8060b54c    00000000   nop
-/ (fcn) fcn.8060b550 36
-|           0x8060b550    0000a290   lbu v0, 0(a1)
-|      ,.-> 0x8060b554    05004010   beqz v0, 0x8060b56c
-|      ||   0x8060b558    0100a524   addiu a1, a1, 1
-|      ||   0x8060b55c    000082a0   sb v0, 0(a0)
-|      ||   0x8060b560    0000a290   lbu v0, 0(a1)
-|      |`=< 0x8060b564    552d1808   j 0x8060b554
-|      |    0x8060b568    01008424   addiu a0, a0, 1
-|      `--> 0x8060b56c    0800e003   jr ra
-\           0x8060b570    000080a0   sb zero, 0(a0)
-            0x8060b574    00000000   nop
-/ (fcn) fcn.8060b578 20
-|           0x8060b578    e0ffbd27   addiu sp, sp, -32
-|           0x8060b57c    542d180c   jal fcn.8060b550
-|           0x8060b580    00000000   nop
-|           0x8060b584    0800e003   jr ra
-\           0x8060b588    2000bd27   addiu sp, sp, 32
-            0x8060b58c    00000000   nop
+EXPECT='0x8060b4f8    00000000   nop
+0x8060b4fc    00000000   nop
+(fcn) fcn.8060b500 80
+0x8060b500    002e0500   sll a1, a1, 0x18
+0x8060b504    032e0500   sra a1, a1, 0x18
+0x8060b508    0f008010   beqz a0, 0x8060b548
+0x8060b50c    21100000   move v0, zero
+0x8060b510    492d1808   j 0x8060b524
+0x8060b514    00008290   lbu v0, 0(a0)
+0x8060b518    0800e003   jr ra
+0x8060b51c    21108000   move v0, a0
+0x8060b520    00008290   lbu v0, 0(a0)
+0x8060b524    07004010   beqz v0, 0x8060b544
+0x8060b528    00000000   nop
+0x8060b52c    00160200   sll v0, v0, 0x18
+0x8060b530    03160200   sra v0, v0, 0x18
+0x8060b534    f8ff4510   beq v0, a1, 0x8060b518
+0x8060b538    00000000   nop
+0x8060b53c    482d1808   j 0x8060b520
+0x8060b540    01008424   addiu a0, a0, 1
+0x8060b544    21100000   move v0, zero
+0x8060b548    0800e003   jr ra
+0x8060b54c    00000000   nop
+(fcn) fcn.8060b550 36
+0x8060b550    0000a290   lbu v0, 0(a1)
+0x8060b554    05004010   beqz v0, 0x8060b56c
+0x8060b558    0100a524   addiu a1, a1, 1
+0x8060b55c    000082a0   sb v0, 0(a0)
+0x8060b560    0000a290   lbu v0, 0(a1)
+0x8060b564    552d1808   j 0x8060b554
+0x8060b568    01008424   addiu a0, a0, 1
+0x8060b56c    0800e003   jr ra
+0x8060b570    000080a0   sb zero, 0(a0)
+0x8060b574    00000000   nop
+(fcn) fcn.8060b578 20
+0x8060b578    e0ffbd27   addiu sp, sp, -32
+0x8060b57c    542d180c   jal fcn.8060b550
+0x8060b580    00000000   nop
+0x8060b584    0800e003   jr ra
+0x8060b588    2000bd27   addiu sp, sp, 32
+0x8060b58c    00000000   nop
 '
 run_test
+
+# the next uses capstone, output should be the same as above,
+# the only thing that changes is hex in literals
 
 NAME="capstone: mips branch delay function detection #1."
 FILE=malloc://160
@@ -351,52 +372,54 @@ e anal.eobjmp=0
 e anal.nopskip=1
 e anal.depth=2
 e asm.nbytes=4
+e asm.lines=false
+e asm.fcnlines=false
 s 0x8060b4f8
 wx 0000000000000000002e0500032e05000f00801021100000492d1808000082900800e003211080000000829007004010000000000016020003160200f8ff451000000000482d180801008424211000000800e003000000000000a290050040100100a524000082a00000a290552d1808010084240800e003000080a000000000e0ffbd27542d180c000000000800e0032000bd270000000000000000
 aa 2> /dev/null
 pd 38
 "
-EXPECT='            0x8060b4f8    00000000   nop
-            0x8060b4fc    00000000   nop
-/ (fcn) fcn.8060b500 80
-|           0x8060b500    002e0500   sll a1, a1, 0x18
-|           0x8060b504    032e0500   sra a1, a1, 0x18
-|       ,=< 0x8060b508    0f008010   beqz a0, 0x8060b548
-|       |   0x8060b50c    21100000   move v0, zero
-|      ,==< 0x8060b510    492d1808   j 0x8060b524
-|      ||   0x8060b514    00008290   lbu v0, (a0)
-|     .---> 0x8060b518    0800e003   jr ra
-|     |||   0x8060b51c    21108000   move v0, a0
-|    .----> 0x8060b520    00008290   lbu v0, (a0)
-|   ,==`--> 0x8060b524    07004010   beqz v0, 0x8060b544
-|   ||| |   0x8060b528    00000000   nop
-|   ||| |   0x8060b52c    00160200   sll v0, v0, 0x18
-|   ||| |   0x8060b530    03160200   sra v0, v0, 0x18
-|   ||`===< 0x8060b534    f8ff4510   beq v0, a1, 0x8060b518
-|   ||  |   0x8060b538    00000000   nop
-|   |`====< 0x8060b53c    482d1808   j 0x8060b520
-|   |   |   0x8060b540    01008424   addiu a0, a0, 1
-|   `-----> 0x8060b544    21100000   move v0, zero
-|       `-> 0x8060b548    0800e003   jr ra
-\           0x8060b54c    00000000   nop
-/ (fcn) fcn.8060b550 36
-|           0x8060b550    0000a290   lbu v0, (a1)
-|      ,.-> 0x8060b554    05004010   beqz v0, 0x8060b56c
-|      ||   0x8060b558    0100a524   addiu a1, a1, 1
-|      ||   0x8060b55c    000082a0   sb v0, (a0)
-|      ||   0x8060b560    0000a290   lbu v0, (a1)
-|      |`=< 0x8060b564    552d1808   j 0x8060b554
-|      |    0x8060b568    01008424   addiu a0, a0, 1
-|      `--> 0x8060b56c    0800e003   jr ra
-\           0x8060b570    000080a0   sb zero, (a0)
-            0x8060b574    00000000   nop
-/ (fcn) fcn.8060b578 20
-|           0x8060b578    e0ffbd27   addiu sp, sp, -0x20
-|           0x8060b57c    542d180c   jal fcn.8060b550
-|           0x8060b580    00000000   nop
-|           0x8060b584    0800e003   jr ra
-\           0x8060b588    2000bd27   addiu sp, sp, 0x20
-            0x8060b58c    00000000   nop
+EXPECT='0x8060b4f8    00000000   nop
+0x8060b4fc    00000000   nop
+(fcn) fcn.8060b500 80
+0x8060b500    002e0500   sll a1, a1, 0x18
+0x8060b504    032e0500   sra a1, a1, 0x18
+0x8060b508    0f008010   beqz a0, 0x8060b548
+0x8060b50c    21100000   move v0, zero
+0x8060b510    492d1808   j 0x8060b524
+0x8060b514    00008290   lbu v0, (a0)
+0x8060b518    0800e003   jr ra
+0x8060b51c    21108000   move v0, a0
+0x8060b520    00008290   lbu v0, (a0)
+0x8060b524    07004010   beqz v0, 0x8060b544
+0x8060b528    00000000   nop
+0x8060b52c    00160200   sll v0, v0, 0x18
+0x8060b530    03160200   sra v0, v0, 0x18
+0x8060b534    f8ff4510   beq v0, a1, 0x8060b518
+0x8060b538    00000000   nop
+0x8060b53c    482d1808   j 0x8060b520
+0x8060b540    01008424   addiu a0, a0, 1
+0x8060b544    21100000   move v0, zero
+0x8060b548    0800e003   jr ra
+0x8060b54c    00000000   nop
+(fcn) fcn.8060b550 36
+0x8060b550    0000a290   lbu v0, (a1)
+0x8060b554    05004010   beqz v0, 0x8060b56c
+0x8060b558    0100a524   addiu a1, a1, 1
+0x8060b55c    000082a0   sb v0, (a0)
+0x8060b560    0000a290   lbu v0, (a1)
+0x8060b564    552d1808   j 0x8060b554
+0x8060b568    01008424   addiu a0, a0, 1
+0x8060b56c    0800e003   jr ra
+0x8060b570    000080a0   sb zero, (a0)
+0x8060b574    00000000   nop
+(fcn) fcn.8060b578 20
+0x8060b578    e0ffbd27   addiu sp, sp, -0x20
+0x8060b57c    542d180c   jal fcn.8060b550
+0x8060b580    00000000   nop
+0x8060b584    0800e003   jr ra
+0x8060b588    2000bd27   addiu sp, sp, 0x20
+0x8060b58c    00000000   nop
 '
 run_test
 


### PR DESCRIPTION
+ unBROKEN the mips tests which now works after fixes in anal_mips_cs
+ little housekeeping, removing lines from EXPECT output because some tests did fail only for differecies in ascii art