### PR TITLE
moved "mips ESIL subtraction in mem refs" to esil tests

### DIFF
--- a/t.anal/mips/mips
+++ b/t.anal/mips/mips
@@ -425,24 +425,3 @@ EXPECT='0x8060b4f8      00000000   nop
 0x8060b58c      00000000   nop
 '
 run_test
-
-NAME="mips ESIL subtraction in mem refs."
-BROKEN=1
-FILE=malloc://20
-ARGS=
-CMDS="e asm.bits=32
-e asm.arch=${PLUGIN}
-e anal.depth=2
-e asm.nbytes=4
-e cfg.bigendian=true
-e asm.esil=true
-e asm.bytes=false
-wx 3c1c0042279c89408f99805003e00008
-pd 4
-"
-EXPECT='            0x00000000      0x420000,gp,=
-            0x00000004      -30400,gp,+,gp,=
-            0x00000008      32688,gp,-,[4],t9,=
-            0x0000000c      ra,pc,=
-'
-run_test

--- a/t.esil/mips
+++ b/t.esil/mips
@@ -1414,3 +1414,23 @@ ar v1
 EXPECT='0xfffff257
 '
 run_test
+
+NAME="negative mem reference"
+ARGS='-m 0x410984'
+FILE=malloc://0x200
+CMDS='
+e asm.arch=mips
+e asm.bits=32
+e cfg.bigendian=true
+ar > /dev/null
+ar t9=0
+ar gp=0
+wx 3c1c0042279c89408f99805011223344
+aes
+aes
+aes
+ar t9
+'
+EXPECT='0x11223344
+'
+run_test


### PR DESCRIPTION
+ corresponds to the new "negative mem reference"
+ refactored to test the feature using emulation