### PR TITLE
adds more tests for bug 3788

### DIFF
--- a/t/search/bug_3788
+++ b/t/search/bug_3788
@@ -13,12 +13,12 @@ run_test
 
 NAME="bug 3788 #2: search with multiple sections"
 FILE=../../bins/vsf/c64-rambo2-rom.vsf
-BROKEN=1
 IGNORE_ERR=1
 CMDS='s 0
+e search.in=io.sections
 /x ac686b6d
 '
-EXPECT='0x0000008a hit0_0 ac686b6d
+EXPECT='0x0000008a hit2_0 ac686b6d
 '
 run_test
 
@@ -32,5 +32,14 @@ e cmd.hit = px 16
 EXPECT='0x0000008a hit0_0 ac6c6c68
 - offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
 0x0000008a  ac6c 6c68 6700 1200 0000 0000 0000 4b0f  .llhg.........K.
+'
+run_test
+
+NAME="bug 3788 #4: no collision in VA"
+FILE=../../bins/nes/Pong.nes
+IGNORE_ERR=1
+CMDS='/x 8512a9208520
+'
+EXPECT='0x00008020 hit0_0 8512a9208520
 '
 run_test


### PR DESCRIPTION
tests 2 is no longer broken when using search.in=io.sections