### PR TITLE
ahi test. remove broken flag

### DIFF
--- a/t/cmd/ahi
+++ b/t/cmd/ahi
@@ -191,7 +191,6 @@ run_test
 
 NAME='ahi 2'
 FILE=malloc://16
-BROKEN=1
 CMDS='
 e asm.arch=x86
 e asm.bits=64


### PR DESCRIPTION
Issue https://github.com/radare/radare2/issues/3766 is fixed and we can remove this *BROKEN* flag.