### PR TITLE
Add new test for sections

### DIFF
--- a/t/sections/section-mapping
+++ b/t/sections/section-mapping
@@ -1,0 +1,31 @@
+#!/bin/sh
+for a in . .. ../.. ; do [ -e $a/tests.sh ] && . $a/tests.sh && break ; done
+
+NAME='map sections correctly'
+FILE=../../bins/dex/Hello.dex
+ARGS='-n -m 0xf0000000'
+CMDS='e io.va=true
+S 0xf000022f 0x0 0x100 0x100 test_section r
+x 0x100 @ 0x0
+'
+EXPECT='- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
+0x00000000  3c69 6e69 743e 0006 4865 6c6c 6f20 000a  <init>..Hello ..
+0x00000010  4865 6c6c 6f2e 6a61 7661 0001 4c00 074c  Hello.java..L..L
+0x00000020  4865 6c6c 6f3b 0002 4c4c 0015 4c6a 6176  Hello;..LL..Ljav
+0x00000030  612f 696f 2f50 7269 6e74 5374 7265 616d  a/io/PrintStream
+0x00000040  3b00 124c 6a61 7661 2f6c 616e 672f 4f62  ;..Ljava/lang/Ob
+0x00000050  6a65 6374 3b00 124c 6a61 7661 2f6c 616e  ject;..Ljava/lan
+0x00000060  672f 5374 7269 6e67 3b00 194c 6a61 7661  g/String;..Ljava
+0x00000070  2f6c 616e 672f 5374 7269 6e67 4275 696c  /lang/StringBuil
+0x00000080  6465 723b 0012 4c6a 6176 612f 6c61 6e67  der;..Ljava/lang
+0x00000090  2f53 7973 7465 6d3b 0001 5600 0256 4c00  /System;..V..VL.
+0x000000a0  0557 6f72 6c64 0013 5b4c 6a61 7661 2f6c  .World..[Ljava/l
+0x000000b0  616e 672f 5374 7269 6e67 3b00 0661 7070  ang/String;..app
+0x000000c0  656e 6400 046d 6169 6e00 036f 7574 0007  end..main..out..
+0x000000d0  7072 696e 746c 6e00 0373 6179 0008 746f  println..say..to
+0x000000e0  5374 7269 6e67 0003 7768 6f00 0401 0007  String..who.....
+0x000000f0  0e3c 2d00 0d01 0007 0ea5 0009 0007 0e01  .<-.............
+'
+EXPECT_ERR=''
+
+run_test


### PR DESCRIPTION
I've added a new test for testing section mapping.

I'm mapping a file to 0xf0000000 and try to create a section in that file which I map to virtual address 0x0. I expect the section I'm mapping (0xf000022f in this case) to be present at 0x0.

The problem this test is trying to test for is shown in this example gist: https://gist.github.com/joelabr/031740d70a5629c887d9

If you want me to change anything or give more information, please tell me.