### PR TITLE
don't drop output of tests when max thread count is never reached and use r2 -v in ouput of parallel test run

### DIFF
--- a/run_tests_parallel.sh
+++ b/run_tests_parallel.sh
@@ -125,9 +125,12 @@ for file in * ; do
       runfile ./ ${file}
    fi
 done
-rm -f $TFS
 
 wait
+cat $TFS
+rm -f $TFS
+TFS=""
+
 if [ $THREADS -gt 1 ]; then
     TESTS_SUCCESS=$(cat ${FILE_SUCCESS})
     TESTS_FATAL=$(cat ${FILE_FATAL})

--- a/run_tests_parallel.sh
+++ b/run_tests_parallel.sh
@@ -52,7 +52,7 @@ fi
 
 . ./tests.sh
 
-radare2 > /dev/null
+radare2 -v
 if [ $? != 0 ]; then
     echo "Cannot find radare2"
     exit 1


### PR DESCRIPTION
Before these changes, I was missing the output of the tests and the r2 -v output when using run_tests_parallel.sh

```

=== Report ===

[2]   SUCCESS
[0]   FIXED
[2]   BROKEN
[0]   FATAL
[0]   FAILED
[50%]     BROKENNESS
```

as compared to the output of run_tests.sh
```
./run_tests.sh t/sections/
radare2 0.10.0 10251 @ darwin-little-x86-64 git.0.10.0-97-g69c3ffa
commit: 69c3ffa9e6c9444a4be265ee02459c898f51caf1 build: 2016-02-03
[BR]  1  0000:
[BR]  1  glue:
[OK]  1  simple-elf:
[OK]  2  simple-elf: display mapped flag in sections list

=== Report ===

[2]   SUCCESS
[0]   FIXED
[2]   BROKEN
[0]   FATAL
[0]   FAILED
[50%]     BROKENNESS
```


With these changes the test output is back

```
./run_tests_parallel.sh t/sections/
radare2 0.10.0 10251 @ darwin-little-x86-64 git.0.10.0-97-g69c3ffa
commit: 69c3ffa9e6c9444a4be265ee02459c898f51caf1 build: 2016-02-03
[BR]  1  0000:
[BR]  1  glue:
[OK]  1  simple-elf:
[OK]  2  simple-elf: display mapped flag in sections list

=== Report ===

[2]   SUCCESS
[0]   FIXED
[2]   BROKEN
[0]   FATAL
[0]   FAILED
[50%]     BROKENNESS
```