### PR TITLE
rahash2: added more SHA2 test cases

### DIFF
--- a/t.tools/rahash2/rahash2
+++ b/t.tools/rahash2/rahash2
@@ -298,13 +298,13 @@ EXPECT='1
 run_test
 
 NAME='rahash2 -s hello1'
-CMDS='!!rahash2 -qa md5 -s hello1'
+CMDS='!rahash2 -qa md5 -s hello1'
 EXPECT='203ad5ffa1d7c650ad681fdff3965cd2
 '
 run_test
 
 NAME='rahash2 -s hello\x31'
-CMDS='!!rahash2 -qa md5 -s hello\\x31'
+CMDS='!rahash2 -qa md5 -s hello\\x31'
 EXPECT='203ad5ffa1d7c650ad681fdff3965cd2
 '
 run_test
@@ -329,6 +329,17 @@ BROKEN=
 EXPECT='0x00000000-0x00000004 md5: 21232f297a57a5a743894a0e4a801fc3
 rahash2: Computed hash matches the expected one.
 '
+
+run_test
+
+NAME='rahash2 -c with incorrect expected hash'
+CMDS='!rahash2 -a md5 -s "admin" -c 21232f297a57a5a743894a0e4a801fc4'
+BROKEN=
+EXPECT='0x00000000-0x00000004 md5: 21232f297a57a5a743894a0e4a801fc3
+'
+IGNORE_ERR=0
+EXPECT_ERR="rahash2: Computed hash doesn't match the expected one.
+"
 
 run_test
 
@@ -417,6 +428,84 @@ BROKEN=
 EXPECT=''
 IGNORE_ERR=0
 EXPECT_ERR='rahash2: Option -c incompatible with -d or -D options.
+'
+
+run_test
+
+# Taken from "Descriptions of SHA-256, SHA-384, and SHA-512" by NIST
+NAME='rahash2 of "abc" using sha256'
+CMDS='!rahash2 -a sha256 -s "abc"'
+BROKEN=
+EXPECT='0x00000000-0x00000002 sha256: ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+'
+
+run_test
+
+# Taken from "Descriptions of SHA-256, SHA-384, and SHA-512" by NIST
+NAME='rahash2 of "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" using sha256'
+CMDS='!rahash2 -a sha256 -s "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"'
+BROKEN=
+EXPECT='0x00000000-0x00000037 sha256: 248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1
+'
+
+run_test
+
+# Taken from "Descriptions of SHA-256, SHA-384, and SHA-512" by NIST
+NAME='rahash2 of "abc" using sha512'
+CMDS='!rahash2 -a sha512 -s "abc"'
+BROKEN=
+EXPECT='0x00000000-0x00000002 sha512: ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f
+'
+
+run_test
+
+# Taken from "Descriptions of SHA-256, SHA-384, and SHA-512" by NIST
+NAME='rahash2 of "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" using sha512'
+CMDS='!rahash2 -a sha512 -s "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"'
+BROKEN=
+EXPECT='0x00000000-0x0000006f sha512: 8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909
+'
+
+run_test
+
+# Taken from "Descriptions of SHA-256, SHA-384, and SHA-512" by NIST3
+NAME='rahash2 of "abc" using sha384'
+CMDS='!rahash2 -a sha384 -s "abc"'
+BROKEN=
+EXPECT='0x00000000-0x00000002 sha384: cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7
+'
+
+run_test
+
+# Taken from "Descriptions of SHA-256, SHA-384, and SHA-512" by NIST
+NAME='rahash2 of "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" using sha384'
+CMDS='!rahash2 -a sha384 -s "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"'
+BROKEN=
+EXPECT='0x00000000-0x0000006f sha384: 09330c33f71147e83d192fc782cd1b4753111b173b3b05d22fa08086e3b0f712fcc7c71a557e2db966c3e9fa91746039
+'
+
+run_test
+
+NAME='rahash2 of empty string using sha256'
+CMDS='!rahash2 -a sha256 -s ""'
+BROKEN=
+EXPECT='0x00000000-0x00000000 sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+'
+
+run_test
+
+NAME='rahash2 of empty string using sha384'
+CMDS='!rahash2 -a sha384 -s ""'
+BROKEN=
+EXPECT='0x00000000-0x00000000 sha384: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+'
+
+run_test
+
+NAME='rahash2 of empty string using sha512'
+CMDS='!rahash2 -a sha512 -s ""'
+BROKEN=
+EXPECT='0x00000000-0x00000000 sha512: cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
 '
 
 run_test


### PR DESCRIPTION
removed !! from 2 tests to fix execution on MSYS2
added wrong hash case for -c option
added empty string hashes for SHA256/384/512
added test string hashes for SHA256/384/512 from "Descriptions of SHA-256, SHA-384, and SHA-512" by NIST

ref: #150 and https://github.com/radare/radare2/issues/3274