### PR TITLE
Adapt baddr to ordered afl

### DIFF
--- a/t.io/baddr
+++ b/t.io/baddr
@@ -106,20 +106,20 @@ ARGS='-B 0xf00000'
 CMDS='aaa
 afl
 '
-EXPECT='0x00f00450  50  1  entry0
-0x00f00482  4  1  fcn.00f00482
+EXPECT='0x00f003ec  35  3  sym._init
+0x00f00420  16  2  sym.imp.__cxa_finalize
+0x00f00430  16  2  loc.imp.__gmon_start__
 0x00f00440  16  2  sym.imp.__libc_start_main
-0x00f005c5  4  1  sym.main
-0x00f004a0  61  4  sym.deregister_tm_clones
+0x00f00450  50  1  entry0
+0x00f00482  4  1  fcn.00f00482
 0x00f00490  4  1  sym.__x86.get_pc_thunk.bx
+0x00f004a0  61  4  sym.deregister_tm_clones
 0x00f004e0  71  4  sym.register_tm_clones
 0x00f00530  71  5  sym.__do_global_dtors_aux
-0x00f00420  16  2  sym.imp.__cxa_finalize
 0x00f00580  69  4  sym.frame_dummy
+0x00f005c5  4  1  sym.main
+0x00f005d0  97  4  sym.__libc_csu_init
 0x00f00640  2  1  sym.__libc_csu_fini
 0x00f00644  20  1  sym._fini
-0x00f005d0  97  4  sym.__libc_csu_init
-0x00f003ec  35  3  sym._init
-0x00f00430  16  2  loc.imp.__gmon_start__
 '
 run_test


### PR DESCRIPTION
This pull request fixes the baddr test case for https://github.com/radare/radare2/pull/4255