### PR TITLE
Actually follow the specification for movdd index

### DIFF
--- a/t.asm/ebc/ebc
+++ b/t.asm/ebc/ebc
@@ -310,7 +310,7 @@ e asm.bits=64
 wx 63f787240010
 pi 1
 '
-EXPECT='movdd r7, @r7(+3, +2337)
+EXPECT='movdd r7, @r7(+7, +584)
 '
 run_test
 


### PR DESCRIPTION
Besides, a friend has disassembled this using IDA pro, and has obtained

    MOVdd       R7, [R7+0x264]

Then, we can compute 0x264 = 4 * 7 + 584 (so IDA seems to emulate 32 bits EFI)
However, neither 2337 + 3 * 4 nor 2337 + 3 * 8 matches 0x264.