### PR TITLE
Add test for basic analysis for z80

### DIFF
--- a/t.anal/z80/basic
+++ b/t.anal/z80/basic
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+for a in . .. ../.. ; do [ -e $a/tests.sh ] && . $a/tests.sh ; done
+
+NAME='Basic search for functions'
+BROKEN=
+FILE=malloc://1024
+CMDS='e asm.arch = z80
+wx 01 210000010000CFC30D00 0203 3CCD1500C9 040506 00C8ED400030FDC9 0708
+af @ 1
+afl~?
+afl~[0]
+afl~[1]
+'
+EXPECT='3
+0x00000001
+0x0000000d
+0x00000016
+10
+5
+7
+'
+run_test


### PR DESCRIPTION
Related to radare/radare2#4500.
It tests that analyser finds 3 subroutines, compares their addresses and sizes.