### PR TITLE
Kill the child to avoid flaky results

### DIFF
--- a/t.archos/Linux-x86_64/dbg_io
+++ b/t.archos/Linux-x86_64/dbg_io
@@ -7,8 +7,9 @@ NAME='dbg.readpc'
 FILE=/bin/ls
 ARGS=-d
 BROKEN=
-CMDS='sr pc
+CMDS='sr PC
 p8 4
+dk 9
 '
 NOT_EXPECT=1
 EXPECT='ffffffff

--- a/t.archos/Linux-x86_64/dbg_step
+++ b/t.archos/Linux-x86_64/dbg_step
@@ -48,6 +48,7 @@ CMDS='dr rax=`dr?rip`
 db rip
 3dso
 ? `dr?rax` - `dr?rip`~?00000000
+dk 9
 '
 EXPECT='0 0x0 00 0 0000:0000 0 00000000 0.0 0.000000f 0.000000
 0


### PR DESCRIPTION
When tests with /bin/ls are left to run the output from ls sometimes ends up in stdout and makes the test fail artificially. Kill the inferior to prevent this.