### PR TITLE
Set a 5 second timeout for tests using rarun2

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -210,7 +210,11 @@ __EOF__
   printf "%s\n" "${CMDS}" > ${TMP_RAD}
   printf "%s" "${EXPECT}" > ${TMP_EXP}
   printf "%s" "${EXPECT_ERR}" > ${TMP_EXR}
-  eval "${R2CMD}"
+  if [ -n "${TIMEOUT}" ]; then
+    eval "rarun2 timeout=${TIMEOUT} -- ${R2CMD}"
+  else
+    eval "${R2CMD}"
+  fi
   CODE=$?
   if [ -n "${IGNORE_RC}" ]; then
     CODE=0


### PR DESCRIPTION
Now that rarun2 supports "--" to treat the remaining stuff as the command line, we can use it's timeout= feature for making sure tests don't hang forever.