### PR TITLE
Immediate string base for right argument.

### DIFF
--- a/t/cmd_ahi
+++ b/t/cmd_ahi
@@ -245,3 +245,16 @@ EXPECT='            0x100001000      c7055f440000.  mov dword [rip + 0x445f], 0 
             0x100001000      c7055f440000.  mov dword [4294988905], 0  ; [0x100005469:4]=-1
 '
 run_test
+
+NAME='ahi s'
+CMDS='e asm.bits=64
+e asm.arch=x86
+wx c74424685265
+pi 1
+ahi s
+pi 1
+'
+EXPECT='mov dword [rsp + 0x68], 0x6c896552
+mov dword [rsp + 0x68], 'Read'
+'
+run_test

--- a/t/cmd_ahi
+++ b/t/cmd_ahi
@@ -247,6 +247,7 @@ EXPECT='            0x100001000      c7055f440000.  mov dword [rip + 0x445f], 0 
 run_test
 
 NAME='ahi s'
+BROKEN=1
 CMDS='e asm.bits=64
 e asm.arch=x86
 wx c74424685265

--- a/t/cmd_ahi
+++ b/t/cmd_ahi
@@ -255,7 +255,7 @@ pi 1
 ahi s
 pi 1
 '
-EXPECT='mov dword [rsp + 0x68], 0x6c896552
+EXPECT="mov dword [rsp + 0x68], 0x6c896552
 mov dword [rsp + 0x68], 'Read'
-'
+"
 run_test


### PR DESCRIPTION
Test if the immediate string base is implemented properly.
In this test only right argument should be changed to string.