### PR TITLE
workaround for tests with timestamps in different TZ

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -31,6 +31,9 @@ cd `dirname $0` 2>/dev/null
 export LANG=C
 export LC_CTYPE=C
 
+# current workaround for timezone
+export TZ=GMT
+
 die() {
   echo "$1"
   exit 1


### PR DESCRIPTION
Running tests on a local machine which is configured for a timezone other than GMT produces failed tests.
This pr is a proposal for a possible workaround for this issue - please feel free to reject.
A proper solution needs to be implemented in r2.
See radare/radare2/issues/2516 and radare/radare2/issues/2111.