### PR TITLE
add tests case for jz "short" syntax

### DIFF
--- a/t.asm/x86/nz/x86_asm
+++ b/t.asm/x86/nz/x86_asm
@@ -328,8 +328,8 @@ test_vector "${PLUGIN}" "jp 6" 0f8a00000000
 test_vector "${PLUGIN}" "js 2" 0f88fcffffff 
 test_vector "${PLUGIN}" "js 6" 0f8800000000 
 test_vector "${PLUGIN}" "jz 6" 0f8400000000
-test_vector "${PLUGIN}" "jz 2" 7400 "br"
-test_vector "${PLUGIN}" "jnz 2" 7500 "br"
+test_vector "${PLUGIN}" "jz short 2" 7400 "br"
+test_vector "${PLUGIN}" "jnz short 2" 7500 "br"
 test_vector "${PLUGIN}" "lahf" 9e "br"
 test_vector "${PLUGIN}" "lar eax, word [eax]" 0f02 "br"
 test_vector "${PLUGIN}" "lcall 0, 0" 9a "br"

--- a/t.asm/x86/nz/x86_asm
+++ b/t.asm/x86/nz/x86_asm
@@ -327,7 +327,9 @@ test_vector "${PLUGIN}" "jp 2" 0f8afcffffff
 test_vector "${PLUGIN}" "jp 6" 0f8a00000000 
 test_vector "${PLUGIN}" "js 2" 0f88fcffffff 
 test_vector "${PLUGIN}" "js 6" 0f8800000000 
-test_vector "${PLUGIN}" "jz 6" 0f8400000000 
+test_vector "${PLUGIN}" "jz 6" 0f8400000000
+test_vector "${PLUGIN}" "jz 2" 7400 "br"
+test_vector "${PLUGIN}" "jnz 2" 7500 "br"
 test_vector "${PLUGIN}" "lahf" 9e "br"
 test_vector "${PLUGIN}" "lar eax, word [eax]" 0f02 "br"
 test_vector "${PLUGIN}" "lcall 0, 0" 9a "br"


### PR DESCRIPTION
Only x86.olly flavour supports short syntax at the moment. Adding tests cases to fix that