### PR TITLE
run_unit: change perm to make it work also on OS X

### DIFF
--- a/run_unit.sh
+++ b/run_unit.sh
@@ -4,7 +4,7 @@
 # export KCOV="kcov /path/to/output"
 # kcov output will be placed in the /path/to/output/index.html
 
-for i in $(find ./unit -name 'test_*' -type f -perm /111); do
+for i in $(find ./unit -name 'test_*' -type f -perm -111); do
 	filename=$(basename "$i")
 	echo "$filename"
 	${KCOV} $i


### PR DESCRIPTION
@crowell what do you think? at the moment unit tests are not working on OS X (travis or mine)