### PR TITLE
Add test for rbp/ebp indexing confusion

### DIFF
--- a/t.asm/x86/nz/x86_asm
+++ b/t.asm/x86/nz/x86_asm
@@ -1235,6 +1235,7 @@ test_vector "${PLUGIN}" "lea rax,[rip-0]" 488d0500000000 "br"
 test_vector "${PLUGIN}" "lea rax,[rip-10]" 488d05f6ffffff "br"
 test_vector "${PLUGIN}" "lea rax,[rip]" 488d0500000000 "br"
 test_vector "${PLUGIN}" "mov [rsi], rbx" 48891e 
+test_vector "${PLUGIN}" "mov byte [rbp-0x100], 2" c68500ffffff02
 test_vector "${PLUGIN}" "mov edx, [rbp-4]" 8b55fc
 test_vector "${PLUGIN}" "mov rax, 0x1122334455667788" 48b88877665544332211 
 test_vector "${PLUGIN}" "mov rax, 0x112233445566778899" 00 "br"


### PR DESCRIPTION
"mov byte [rbp-0x100], 2" was converted to "mov byte [ebp-0x100], 2"