### PR TITLE
[t.esil] arm-16: add test for arithmetic shift instruction (#6388)

### DIFF
--- a/t.esil/arm-16
+++ b/t.esil/arm-16
@@ -371,3 +371,36 @@ ar r2
 EXPECT='0xeeddccbb
 '
 run_test
+
+# logic vs arithmetic shifts
+NAME="lsrs r4, r4, 2"
+FILE=malloc://0x200
+CMDS='
+e asm.arch=arm
+e asm.bits=16
+ar > /dev/null
+ar r4=-8
+wx a408
+aes
+ar r4
+'
+EXPECT='0x3ffffffe
+'
+run_test
+
+# -8 == 0xfffffff8 (Two's complement on 32bit)
+NAME="asrs r4, r4, 2"
+BROKEN=true
+FILE=malloc://0x200
+CMDS='
+e asm.arch=arm
+e asm.bits=16
+ar > /dev/null
+ar r4=-8
+wx a410
+aes
+ar r4
+'
+EXPECT='0xfffffffe
+'
+run_test


### PR DESCRIPTION
This documents a possible bug reported in [issue #6388](https://github.com/radare/radare2/issues/6388).