### PR TITLE
pe32+ -> pe64

### DIFF
--- a/t.formats/pe/pe64
+++ b/t.formats/pe/pe64
@@ -2,7 +2,7 @@
 
 for a in . .. ../.. ; do [ -e $a/tests.sh ] && . $a/tests.sh ; done
 
-NAME='pe32+ msvc main'
+NAME='pe64 msvc main'
 FILE=../../bins/pe/simplest-msvc64.exe
 ARGS=
 CMDS='iM~addr


### PR DESCRIPTION
Switched from pe32+ to pe64 for consistency with radare2 file naming in libr.