### PR TITLE
Fixed xref tests related to radare/radare2#7192

### DIFF
--- a/t.anal/others_anal/xref
+++ b/t.anal/others_anal/xref
@@ -15,12 +15,7 @@ aa
 axt @ str.Hello_World'
 EXPECT='data 0x40050a mov edi, str.Hello_World in sym.main
 '
-if [ -n "${TRAVIS}" ]; then
-  unset BROKEN
-  return
-else
-  run_test
-fi
+run_test
 
 NAME="axt capstone x86"
 BROKEN=

--- a/t.anal/others_anal/xref
+++ b/t.anal/others_anal/xref
@@ -88,7 +88,7 @@ e asm.relsub=true
 axt @ sym.imp.msvcrt.dll_printf
 '
 EXPECT='data 0xffffffffffff100a call qword [rip + 0xd8] in entry0
-data 0xffffffffffff100a call qword [sym.imp.msvcrt.dll_printf] in entry0
+data 0xffffffffffff100a call qword sym.imp.msvcrt.dll_printf in entry0
 '
 run_test
 
@@ -256,7 +256,7 @@ CMDS='
 aaa
 axt@0x0804a01c
 '
-EXPECT='data 0x80483ee mov dword [obj.a], 0x1337 in sym.main
+EXPECT='data 0x80483ee mov dword obj.a, 0x1337 in sym.main
 '
 run_test
 


### PR DESCRIPTION
The `qword` in `call qword` already shows that the call is indirect.