### PR TITLE
cmd_search: remove extra backslash, add another one at the end

### DIFF
--- a/t/cmd_search
+++ b/t/cmd_search
@@ -49,10 +49,10 @@ FILE='malloc://1024'
 ARGS=
 BROKEN=
 CMDS='
-wx 666f6f00
-/j foo\x00
+wx 666f6f005c
+/j foo\x00\\
 '
-EXPECT='[{"offset": 0,"id:":0,"data":"foo\\u0000"}]
+EXPECT='[{"offset": 0,"id:":0,"data":"foo\u0000\\"}]
 '
 run_test
 


### PR DESCRIPTION
This reverts the extra backslash added in the wrong place by cfa30d06 and adds an extra 0x5c byte at the end of the searched string so that there's a backslash to test escaping for r2 PR 7294

For https://github.com/radare/radare2/pull/7294