### PR TITLE
Update aac test with MIPS likely branches analyzed

### DIFF
--- a/t.anal/others_anal/aac
+++ b/t.anal/others_anal/aac
@@ -8,7 +8,7 @@ FILE=../../bins/elf/analysis/mipsbe-busybox
 CMDS="aac
 afl~?
 "
-EXPECT="1318
+EXPECT="1270
 "
 run_test
 


### PR DESCRIPTION
Analysis was discarding the branch likely targets and including many 'loc' references and an errant 'sym.imp.__umoddi3'.
Tests pass with radare/radare2#7360