### PR TITLE
Tests whether refaddr is shown only once in cmts

### DIFF
--- a/t.anal/others_anal/reflines
+++ b/t.anal/others_anal/reflines
@@ -141,27 +141,27 @@ EXPECT='|       ,=< 0x000113bd      je 0x1144e
 |       |   0x000113c8      call sym.imp.strrchr                      ; char*strrchr(char *s, int c)
 |       |   0x000113cd      test rax, rax
 |      ,==< 0x000113d0      je 0x11424
-|      ||   0x000113d2      lea rdx, [rax + 1]                         ; 0x1
+|      ||   0x000113d2      lea rdx, [rax + 1]
 |      ||   0x000113d6      mov rcx, rdx
 |      ||   0x000113d9      sub rcx, rbx
 |      ||   0x000113dc      cmp rcx, 6
 |     ,===< 0x000113e0      jle 0x11424
 |     |||   0x000113e2      lea rsi, [rax - 6]
 |     |||   0x000113e6      mov ecx, 7
-|     |||   0x000113eb      lea rdi, [rip + 0x7ebb]                    ; 0x192ad ; str._.libs_ ; "/.libs/" @ 0x192ad
+|     |||   0x000113eb      lea rdi, [rip + 0x7ebb]                    ; str._.libs_ ; 0x192ad ; "/.libs/"
 |     |||   0x000113f2      repe cmpsb byte [rsi], byte ptr [rdi]      ; [0x2700000000:1]=255 ; 0
 |    ,====< 0x000113f4      jne 0x11424
 |    ||||   0x000113f6      mov ecx, 3
 |    ||||   0x000113fb      mov rsi, rdx
 |    ||||   0x000113fe      mov rbx, rdx
-|    ||||   0x00011401      lea rdi, [rip + 0x7ead]                    ; 0x192b5 ; "lt-"
+|    ||||   0x00011401      lea rdi, [rip + 0x7ead]                    ; "lt-" ; 0x192b5
 |    ||||   0x00011408      repe cmpsb byte [rsi], byte ptr [rdi]      ; [0x2700000000:1]=255 ; 0
 |    ||||   0x0001140a      seta sil
 |    ||||   0x0001140e      setb cl
 |    ||||   0x00011411      cmp sil, cl
 |   ,=====< 0x00011414      jne 0x11424
-|   |||||   0x00011416      lea rbx, [rax + 4]                         ; 0x4
-|   |||||   0x0001141a      mov rax, qword [rip + 0xdeaf]              ; [0x1f2d0:8]=0 ; LEA reloc.program_invocation_name_208 ; reloc.program_invocation_name_208
+|   |||||   0x00011416      lea rbx, [rax + 4]
+|   |||||   0x0001141a      mov rax, qword [rip + 0xdeaf]              ; reloc.program_invocation_name_208 ; [0x1f2d0:8]=0
 |   |||||   0x00011421      mov qword [rax], rbx
 |   |||||      ; JMP XREF from 0x000113d0 (sub.program_invocation_name_112_390)
 |   |||||      ; JMP XREF from 0x000113e0 (sub.program_invocation_name_112_390)
@@ -207,7 +207,7 @@ EXPECT='|           0x00003ca6      cmp eax, 2
 |    || |      ; JMP XREF from 0x00004602 (main)
 |    || |      ; JMP XREF from 0x00004c38 (main)
 |    || |      ; JMP XREF from 0x00003ce1 (main)
-|    `----> 0x00003cf9      lea rdi, [rip + 0x14fb4]                   ; 0x18cb4 ; str.QUOTING_STYLE ; "QUOTING_STYLE" @ 0x18cb4
+|    `----> 0x00003cf9      lea rdi, [rip + 0x14fb4]                   ; str.QUOTING_STYLE ; 0x18cb4 ; "QUOTING_STYLE"
 '
 run_test
 
@@ -248,7 +248,7 @@ EXPECT='|           0x00003ca6      cmp eax, 2
 |  |   |       ; JMP XREF from 0x00004602 (main)
 |  |   |       ; JMP XREF from 0x00004c38 (main)
 |  |   |       ; JMP XREF from 0x00003ce1 (main)
-| --------> 0x00003cf9      lea rdi, [rip + 0x14fb4]                   ; 0x18cb4 ; str.QUOTING_STYLE ; "QUOTING_STYLE" @ 0x18cb4
+| --------> 0x00003cf9      lea rdi, [rip + 0x14fb4]                   ; str.QUOTING_STYLE ; 0x18cb4 ; "QUOTING_STYLE"
 '
 run_test
 
@@ -289,7 +289,7 @@ EXPECT='|           0x00003ca6      cmp eax, 2
 |  |   |       ; JMP XREF from 0x00004602 (main)
 |  |   |       ; JMP XREF from 0x00004c38 (main)
 |  |   |       ; JMP XREF from 0x00003ce1 (main)
-| --------> 0x00003cf9      lea rdi, [rip + 0x14fb4]                   ; 0x18cb4 ; str.QUOTING_STYLE ; "QUOTING_STYLE" @ 0x18cb4
+| --------> 0x00003cf9      lea rdi, [rip + 0x14fb4]                   ; str.QUOTING_STYLE ; 0x18cb4 ; "QUOTING_STYLE"
 '
 run_test
 

--- a/t/cmd_pd
+++ b/t/cmd_pd
@@ -233,7 +233,7 @@ e scr.columns = 90
 aa
 pd 1 @ 0x0040050a
 '
-EXPECT='|           0x0040050a      bfc4054000     mov edi, str.Hello_World    ; "Hello World" @ 0x4005c4
+EXPECT='|           0x0040050a      bfc4054000     mov edi, str.Hello_World    ; 0x4005c4 ; "Hello World"
 '
 run_test
 
@@ -247,7 +247,7 @@ e scr.columns = 90
 aa
 pd 1 @ 0x0040050a
 '
-EXPECT='|           0x0040050a      bfc4054000     mov edi, str.Hello_World    ; "Hello World" @ 0x4005c4
+EXPECT='|           0x0040050a      bfc4054000     mov edi, str.Hello_World    ; 0x4005c4 ; "Hello World"
 '
 run_test
 
@@ -304,7 +304,7 @@ EXPECT='            ;-- main:
             ;-- main:
             0x00400506      55             push rbp
             0x00400507      4889e5         mov rbp, rsp
-            0x0040050a      bfc4054000     mov edi, str.Hello_World    ; "Hello World" @ 0x4005c4
+            0x0040050a      bfc4054000     mov edi, str.Hello_World    ; 0x4005c4 ; "Hello World"
 '
 
 run_test
@@ -320,7 +320,7 @@ EXPECT='            ;-- main:
             ;-- main:
             0x00400506      55             push rbp
             0x00400507      4889e5         mov rbp, rsp
-            0x0040050a      bfc4054000     mov edi, str.Hello_World    ; "Hello World" @ 0x4005c4
+            0x0040050a      bfc4054000     mov edi, str.Hello_World    ; 0x4005c4 ; "Hello World"
 '
 
 run_test
@@ -582,9 +582,9 @@ pd 1 @ 0x0001145f
 e asm.cmtright=false
 pd 1 @ 0x0001145f
 '
-EXPECT='            0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call._n ; 0x1b5d8 ; "A NULL argv[0] was passed through an exec system call.." @ 0x1b5d8
+EXPECT='            0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call._n ; 0x1b5d8 ; "A NULL argv[0] was passed through an exec system call.."
                ; 0x1b5d8
-               ; "A NULL argv[0] was passed through an exec system call.." @ 0x1b5d8
+               ; "A NULL argv[0] was passed through an exec system call.."
             0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call._n
 '
 run_test
@@ -599,10 +599,9 @@ pd 1 @ 0x0001145f
 e asm.cmtright=false
 pd 1 @ 0x0001145f
 '
-EXPECT='            0x0001145f      488d3d72a100.  lea rdi, 0x0001b5d8         ; NULL_error ; 0x1b5d8 ; "A NULL argv[0] was passed through an exec system call.." @ 0x1b5d8
+EXPECT='            0x0001145f      488d3d72a100.  lea rdi, 0x0001b5d8         ; NULL_error ; "A NULL argv[0] was passed through an exec system call.."
                ; NULL_error
-               ; 0x1b5d8
-               ; "A NULL argv[0] was passed through an exec system call.." @ 0x1b5d8
+               ; "A NULL argv[0] was passed through an exec system call.."
             0x0001145f      488d3d72a100.  lea rdi, 0x0001b5d8
 '
 run_test
@@ -615,8 +614,9 @@ pd 1 @ 0x004010f0
 e asm.cmtright=false
 pd 1 @ 0x004010f0
 '
-EXPECT='            0x004010f0      68b8214000     push str.Number_of_CPU__d_n ; "Number of CPU %d\x0a" @ 0x4021b8
-               ; "Number of CPU %d\x0a" @ 0x4021b8
+EXPECT='            0x004010f0      68b8214000     push str.Number_of_CPU__d_n ; 0x4021b8 ; "Number of CPU %d\x0a"
+               ; 0x4021b8
+               ; "Number of CPU %d\x0a"
             0x004010f0      68b8214000     push str.Number_of_CPU__d_n
 '
 run_test
@@ -631,9 +631,9 @@ pd 1 @ 0x004010f0
 e asm.cmtright=false
 pd 1 @ 0x004010f0
 '
-EXPECT='            0x004010f0      68b8214000     push 0x4021b8               ; num_cpu ; "Number of CPU %d\x0a" @ 0x4021b8
+EXPECT='            0x004010f0      68b8214000     push 0x4021b8               ; num_cpu ; "Number of CPU %d\x0a"
                ; num_cpu
-               ; "Number of CPU %d\x0a" @ 0x4021b8
+               ; "Number of CPU %d\x0a"
             0x004010f0      68b8214000     push 0x4021b8
 '
 run_test
@@ -695,14 +695,14 @@ e asm.cmtright=false
 pd 1 @ 0x140001004
 pd 1 @ 0x140001010
 '
-EXPECT='            0x140001004      488d05f54f01.  lea rax, str._tANSI_r_n    ; section..data ; 0x140016000 ; ".ANSI.." @ 0x140016000
-            0x140001010      488d05f14f01.  lea rax, str._twide_r_n    ; 0x140016008 ; "\x09wide\x0d\x0a" @ 0x140016008
+EXPECT='            0x140001004      488d05f54f01.  lea rax, str._tANSI_r_n    ; section..data ; 0x140016000 ; ".ANSI.."
+            0x140001010      488d05f14f01.  lea rax, str._twide_r_n    ; 0x140016008 ; "\x09wide\x0d\x0a"
                ; section..data
                ; 0x140016000
-               ; ".ANSI.." @ 0x140016000
+               ; ".ANSI.."
             0x140001004      488d05f54f01.  lea rax, str._tANSI_r_n
                ; 0x140016008
-               ; "\x09wide\x0d\x0a" @ 0x140016008
+               ; "\x09wide\x0d\x0a"
             0x140001010      488d05f14f01.  lea rax, str._twide_r_n
 '
 run_test
@@ -727,9 +727,9 @@ pd 1 @ 0x004010c6
 e asm.cmtright=false
 pd 1 @ 0x004010c6
 '
-EXPECT='            0x004010c6      ff1508204000   call dword [0x402008]       ; sym.imp.KERNEL32.dll_GetProcAddress ; " *" @ 0x402008
+EXPECT='            0x004010c6      ff1508204000   call dword [0x402008]       ; sym.imp.KERNEL32.dll_GetProcAddress ; " *"
                ; sym.imp.KERNEL32.dll_GetProcAddress
-               ; " *" @ 0x402008
+               ; " *"
             0x004010c6      ff1508204000   call dword [0x402008]
 '
 run_test

--- a/t/noreturn
+++ b/t/noreturn
@@ -90,7 +90,7 @@ EXPECT='            ;-- main:
 |       ,=< 0x00400572      740a           je 0x40057e
 |       |   0x00400574      bf00000000     mov edi, 0
 |       |   0x00400579      e8d2feffff     call sym.imp.exit          ; void exit(int status)
-|       `-> 0x0040057e      bf20064000     mov edi, str.hello          ; "hello" @ 0x400620
+|       `-> 0x0040057e      bf20064000     mov edi, str.hello          ; 0x400620 ; "hello"
 |           0x00400583      e8a8feffff     call sym.imp.puts          ; int puts(const char *s)
 |           0x00400588      b800000000     mov eax, 0
 |           0x0040058d      c9             leave

--- a/t/pdf
+++ b/t/pdf
@@ -97,7 +97,7 @@ EXPECT='            ;-- main:
 |           0x00400531      4883ec10       sub rsp, 0x10
 |           0x00400535      c745fc000000.  mov dword [rbp-0x4], 0x0    ; dwarftest.c:7  for (i = 0; i < 5; i++) { ; [0xfc:4]=0
 |       ,=< 0x0040053c      eb0e           jmp 0x40054c
-|      .--> 0x0040053e      bfe4054000     mov edi, str.dwarftest      ; dwarftest.c:8   printf ("dwarftest\n"); ; "dwarftest" @ 0x4005e4
+|      .--> 0x0040053e      bfe4054000     mov edi, str.dwarftest      ; dwarftest.c:8   printf ("dwarftest\n"); ; 0x4005e4 ; "dwarftest"
 |      !|   0x00400543      e8c8feffff     call sym.imp.puts
 |      !|   0x00400548      8345fc01       add dword [rbp-0x4], 0x1    ; dwarftest.c:7  for (i = 0; i < 5; i++) {
 |      !|      ; JMP XREF from 0x0040053c (main)
@@ -136,7 +136,7 @@ EXPECT='            ;-- main:
 |           0x00400531      4883ec10       sub rsp, 0x10
 |           0x00400535      c745fc000000.  mov dword [rbp-0x4], 0x0    ; /tmp/r2-regressions/.//dwarftest.c:7  for (i = 0; i < 5; i++) { ; [0xfc:4]=0
 |       ,=< 0x0040053c      eb0e           jmp 0x40054c
-|      .--> 0x0040053e      bfe4054000     mov edi, str.dwarftest      ; /tmp/r2-regressions/.//dwarftest.c:8   printf ("dwarftest\n"); ; "dwarftest" @ 0x4005e4
+|      .--> 0x0040053e      bfe4054000     mov edi, str.dwarftest      ; /tmp/r2-regressions/.//dwarftest.c:8   printf ("dwarftest\n"); ; 0x4005e4 ; "dwarftest"
 |      !|   0x00400543      e8c8feffff     call sym.imp.puts
 |      !|   0x00400548      8345fc01       add dword [rbp-0x4], 0x1    ; /tmp/r2-regressions/.//dwarftest.c:7  for (i = 0; i < 5; i++) {
 |      !|      ; JMP XREF from 0x0040053c (main)


### PR DESCRIPTION
Tests for radare/radare2#7398. Supersedes #827.