### PR TITLE
Fix asm/mips tests to reflect current capstone status

### DIFF
--- a/t.asm/mips/mips
+++ b/t.asm/mips/mips
@@ -16,6 +16,24 @@ fi
 # regressions in LDC2, which are properly disassembled by GNU
 CMDS='
 e asm.arch='${1}'
+e asm.bits=32
+s 4
+wx '${3}'
+pi 1
+'
+EXPECT="${4}
+"
+run_test
+}
+
+test_vector64() {
+NAME="${1}: [${2}]"
+FILE=malloc://32
+if [ "${5}" = "br" ]; then
+	BROKEN=1
+fi
+CMDS='
+e asm.arch='${1}'
 e asm.bits=64
 s 4
 wx '${3}'
@@ -62,14 +80,14 @@ test_vector "${PLUGIN}" "JALX" 01000074 'jalx 4'
 test_vector "${PLUGIN}" "LB" 00000080 'lb zero, (zero)'
 test_vector "${PLUGIN}" "LBU" 00000090 'lbu zero, (zero)'
 test_vector "${PLUGIN}" "LDC1" 000000d4 'ldc1 f0, (zero)'
-test_vector "${PLUGIN}" "LDC2" 000000d8 'ldc2 0, (zero)' br
+test_vector "${PLUGIN}" "LDC2" 000000d8 'ldc2 0, (zero)'
 test_vector "${PLUGIN}" "LH" 00000084 'lh zero, (zero)'
 test_vector "${PLUGIN}" "LHU" 00000094 'lhu zero, (zero)'
 test_vector "${PLUGIN}" "LL" 000000c0 'll zero, (zero)'
 test_vector "${PLUGIN}" "LUI" 0000003c "lui zero, 0"
 test_vector "${PLUGIN}" "LW" 0000008c 'lw zero, (zero)'
 test_vector "${PLUGIN}" "LWC1" 000000c4 'lwc1 f0, (zero)'
-test_vector "${PLUGIN}" "LWC2" 000000c8 'lwc2 0, (zero)' br
+test_vector "${PLUGIN}" "LWC2" 000000c8 'lwc2 0, (zero)'
 test_vector "${PLUGIN}" "LWL" 00000088 'lwl zero, (zero)'
 test_vector "${PLUGIN}" "LWR" 00000098 'lwr zero, (zero)'
 test_vector "${PLUGIN}" "MFC1" 00000044 'mfc1 zero, f0'
@@ -78,33 +96,33 @@ test_vector "${PLUGIN}" "ORI" 00000035 "ori zero, t0, 0"
 test_vector "${PLUGIN}" "SB" 000000a0 'sb zero, (zero)'
 test_vector "${PLUGIN}" "SC" 000000e0 'sc zero, (zero)'
 test_vector "${PLUGIN}" "SDC1" 000000f4 'sdc1 f0, (zero)'
-test_vector "${PLUGIN}" "SDC2" 000000f8 'sdc2 0, (zero)' br
+test_vector "${PLUGIN}" "SDC2" 000000f8 'sdc2 0, (zero)'
 test_vector "${PLUGIN}" "SH" 000000a4 'sh zero, (zero)'
 test_vector "${PLUGIN}" "SLTI" 00000028 "slti zero, zero, 0"
 test_vector "${PLUGIN}" "SLTIU" 0000002c "sltiu zero, zero, 0"
 test_vector "${PLUGIN}" "SW" 000000ac 'sw zero, (zero)'
 test_vector "${PLUGIN}" "SWC1" 000000e4 'swc1 f0, (zero)'
-test_vector "${PLUGIN}" "SWC2" 000000e8 'swc2 0, (zero)' br
+test_vector "${PLUGIN}" "SWC2" 000000e8 'swc2 0, (zero)'
 test_vector "${PLUGIN}" "SWL" 000000a8 'swl zero, (zero)'
 test_vector "${PLUGIN}" "SWR" 000000b8 'swr zero, (zero)'
 test_vector "${PLUGIN}" "XORI" 00000038 "xori zero, zero, 0"
 
 # Not defined in MIPS III>=3.2
-test_vector "${PLUGIN}" "LWC3" 000000cc 'lwc3 0, (zero)'
-test_vector "${PLUGIN}" "SWC3" 000000ec 'swc3 0, (zero)'
+test_vector "${PLUGIN}" "LWC3" 000000cc 'lwc3 0, (zero)' "br"
+test_vector "${PLUGIN}" "SWC3" 000000ec 'swc3 0, (zero)' "br"
 
 # Only 64bit 
-test_vector "${PLUGIN}" "DADDI" 00000060 'daddi zero, zero, 0'
-test_vector "${PLUGIN}" "DADDIU" 00000064 'daddiu zero, zero, 0'
-test_vector "${PLUGIN}" "LD" 000000dc 'ld zero, 0(zero)' "br"
-test_vector "${PLUGIN}" "LDL" 00000068 'ldl zero, (zero)'
-test_vector "${PLUGIN}" "LDR" 0000006c 'ldr zero, (zero)'
-test_vector "${PLUGIN}" "LLD" 000000d0 'lld zero, (zero)'
-test_vector "${PLUGIN}" "LWU" 0000009c 'lwu zero, (zero)'
-test_vector "${PLUGIN}" "SCD" 000000f0 'scd zero, (zero)'
-test_vector "${PLUGIN}" "SD" 000000fc 'sd zero, (zero)' "br"
-test_vector "${PLUGIN}" "SDL" 000000b0 'sdl zero, (zero)'
-test_vector "${PLUGIN}" "SDR" 000000b4 'sdr zero, (zero)'
+test_vector64 "${PLUGIN}" "DADDI" 00000060 'daddi zero, zero, 0'
+test_vector64 "${PLUGIN}" "DADDIU" 00000064 'daddiu zero, zero, 0'
+test_vector64 "${PLUGIN}" "LD" 000000dc 'ld zero, 0(zero)' "br"
+test_vector64 "${PLUGIN}" "LDL" 00000068 'ldl zero, (zero)'
+test_vector64 "${PLUGIN}" "LDR" 0000006c 'ldr zero, (zero)'
+test_vector64 "${PLUGIN}" "LLD" 000000d0 'lld zero, (zero)'
+test_vector64 "${PLUGIN}" "LWU" 0000009c 'lwu zero, (zero)'
+test_vector64 "${PLUGIN}" "SCD" 000000f0 'scd zero, (zero)'
+test_vector64 "${PLUGIN}" "SD" 000000fc 'sd zero, (zero)'
+test_vector64 "${PLUGIN}" "SDL" 000000b0 'sdl zero, (zero)'
+test_vector64 "${PLUGIN}" "SDR" 000000b4 'sdr zero, (zero)'
 
 # Co-processor dependant
 test_vector "${PLUGIN}" "C0" 00000042 "c0 0x0" "br"


### PR DESCRIPTION
could be merged after https://github.com/radare/radare2/pull/7632

currently there's no way for capstone to correctly disassemble mips I/II-only instructions in 64 bit mode, like `sdc3` `swc3` etc. because they swallow other valid mips64 instructions, while are disabled in 32 bit mode