### PR TITLE
Fix mips asm tests

### DIFF
--- a/t.asm/mips/mips
+++ b/t.asm/mips/mips
@@ -26,6 +26,26 @@ EXPECT="${4}
 run_test
 }
 
+test_vector_v2() {
+NAME="${1}: [${2}]"
+FILE=malloc://32
+if [ "${5}" = "br" ]; then
+	BROKEN=1
+fi
+# 'v2' cpu is needed to enable coprocessor 3
+CMDS='
+e asm.arch='${1}'
+e asm.bits=64
+e asm.cpu=v2
+s 4
+wx '${3}'
+pi 1
+'
+EXPECT="${4}
+"
+run_test
+}
+
 test_vector "${PLUGIN}" "ADD.S" 00000046 'add.s f0, f0, f0'
 test_vector "${PLUGIN}" "ADDI" 00000020 "addi zero, zero, 0"
 test_vector "${PLUGIN}" "ADDIU" 00000025 "addiu zero, t0, 0"
@@ -90,8 +110,8 @@ test_vector "${PLUGIN}" "SWR" 000000b8 'swr zero, (zero)'
 test_vector "${PLUGIN}" "XORI" 00000038 "xori zero, zero, 0"
 
 # Not defined in MIPS III>=3.2
-test_vector "${PLUGIN}" "LWC3" 000000cc 'lwc3 0, (zero)'
-test_vector "${PLUGIN}" "SWC3" 000000ec 'swc3 0, (zero)'
+test_vector_v2 "${PLUGIN}" "LWC3" 000000cc 'lwc3 0, (zero)'
+test_vector_v2 "${PLUGIN}" "SWC3" 000000ec 'swc3 0, (zero)'
 
 # Only 64bit 
 test_vector "${PLUGIN}" "DADDI" 00000060 'daddi zero, zero, 0'
@@ -102,7 +122,7 @@ test_vector "${PLUGIN}" "LDR" 0000006c 'ldr zero, (zero)'
 test_vector "${PLUGIN}" "LLD" 000000d0 'lld zero, (zero)'
 test_vector "${PLUGIN}" "LWU" 0000009c 'lwu zero, (zero)'
 test_vector "${PLUGIN}" "SCD" 000000f0 'scd zero, (zero)'
-test_vector "${PLUGIN}" "SD" 000000fc 'sd zero, (zero)' "br"
+test_vector "${PLUGIN}" "SD" 000000fc 'sd zero, (zero)'
 test_vector "${PLUGIN}" "SDL" 000000b0 'sdl zero, (zero)'
 test_vector "${PLUGIN}" "SDR" 000000b4 'sdr zero, (zero)'
 


### PR DESCRIPTION
- set “v2” cpu for coprocessor 3 instructions
- unbroken SD test

to be merged after https://github.com/radare/radare2/pull/7643