### PR TITLE
Fixed tests where search with json output escapes twice

### DIFF
--- a/t/cmd_search
+++ b/t/cmd_search
@@ -60,7 +60,7 @@ CMDS='
 wx 666f6f005c
 /j foo\x00\\
 '
-EXPECT='[{"offset": 0,"id:":0,"type":"string","data":"foo\u0000\\\\"}]
+EXPECT='[{"offset": 0,"id:":0,"type":"string","data":"foo\u0000\\"}]
 '
 run_test
 

--- a/t/cmd_search_hit
+++ b/t/cmd_search_hit
@@ -39,7 +39,7 @@ FILE='malloc://1024'
 CMDS='wx 005c
 /j \x00\\
 '
-EXPECT='[{"offset": 0,"id:":0,"type":"string","data":"\u0000\\\\"}]
+EXPECT='[{"offset": 0,"id:":0,"type":"string","data":"\u0000\\"}]
 '
 run_test
 


### PR DESCRIPTION
Fixed tests for radare/radare2#7659.