### PR TITLE
Switched tests from \xhh hex escapes to \nnn octal escapes

### DIFF
--- a/t/cmd_pd
+++ b/t/cmd_pd
@@ -715,15 +715,15 @@ pd 1 @ 0x140001004
 pd 1 @ 0x140001010
 pd 1 @ 0x14000101c
 '
-EXPECT='            0x140001004      488d05f54f01.  lea rax, str._tANSI_esc:__e_33m_r_n ; section..data ; 0x140016000 ; "\tANSI\\esc: \x1b[33m\r\n"
-            0x140001010      488d05015001.  lea rax, str._twide_esc:__e_0m___r_n ; 0x140016018 ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+EXPECT='            0x140001004      488d05f54f01.  lea rax, str._tANSI_esc:__e_33m_r_n ; section..data ; 0x140016000 ; "\tANSI\\esc: \033[33m\r\n"
+            0x140001010      488d05015001.  lea rax, str._twide_esc:__e_0m___r_n ; 0x140016018 ; u"\twide\\esc: \033[0m\241\r\n"
             0x14000101c      488d051d5001.  lea rax, str._wide__in_Arabic:_________ ; 0x140016040 ; u"\"wide\" in Arabic: \u0648\u0627\u0633\u0639"
                ; section..data
                ; 0x140016000
-               ; "\tANSI\\esc: \x1b[33m\r\n"
+               ; "\tANSI\\esc: \033[33m\r\n"
             0x140001004      488d05f54f01.  lea rax, str._tANSI_esc:__e_33m_r_n
                ; 0x140016018
-               ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+               ; u"\twide\\esc: \033[0m\241\r\n"
             0x140001010      488d05015001.  lea rax, str._twide_esc:__e_0m___r_n
                ; 0x140016040
                ; u"\"wide\" in Arabic: \u0648\u0627\u0633\u0639"
@@ -748,15 +748,15 @@ pd 1 @ 0x140001010
 e asm.cmtright=false
 pd 1 @ 0x140001010
 '
-EXPECT='            0x140001010      488d05015001.  lea rax, 0x140016018       ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+EXPECT='            0x140001010      488d05015001.  lea rax, 0x140016018       ; u"\twide\\esc: \033[0m\241\r\n"
             0x140001028      488d05415001.  lea rax, 0x140016070       ; str._fFormfeed_at_start
-               ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+               ; u"\twide\\esc: \033[0m\241\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018
                ; str._fFormfeed_at_start
             0x140001028      488d05415001.  lea rax, 0x140016070
-            0x140001010      488d05015001.  lea rax, 0x140016018       ; str.wide ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+            0x140001010      488d05015001.  lea rax, 0x140016018       ; str.wide ; u"\twide\\esc: \033[0m\241\r\n"
                ; str.wide
-               ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+               ; u"\twide\\esc: \033[0m\241\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018
 '
 run_test
@@ -771,9 +771,9 @@ pd 1 @ 0x140001010
 e asm.cmtright=false
 pd 1 @ 0x140001010
 '
-EXPECT='            0x140001010      488d05015001.  lea rax, 0x140016018       ; str._twide_esc:__e_0m___r_n ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+EXPECT='            0x140001010      488d05015001.  lea rax, 0x140016018       ; str._twide_esc:__e_0m___r_n ; u"\twide\\esc: \033[0m\241\r\n"
                ; str._twide_esc:__e_0m___r_n
-               ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+               ; u"\twide\\esc: \033[0m\241\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018
 '
 run_test
@@ -818,9 +818,9 @@ pd 1 @ 0x140001010
 e asm.cmtoff=nodup
 pd 1 @ 0x140001010
 '
-EXPECT='            0x140001010      488d05015001.  lea rax, str._twide_esc:__e_0m___r_n ; u"\twide\\esc: \x1b[0m\xa1\r\n"
-            0x140001010      488d05015001.  lea rax, 0x140016018       ; 0x140016018 ; u"\twide\\esc: \x1b[0m\xa1\r\n"
-            0x140001010      488d05015001.  lea rax, 0x140016018       ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+EXPECT='            0x140001010      488d05015001.  lea rax, str._twide_esc:__e_0m___r_n ; u"\twide\\esc: \033[0m\241\r\n"
+            0x140001010      488d05015001.  lea rax, 0x140016018       ; 0x140016018 ; u"\twide\\esc: \033[0m\241\r\n"
+            0x140001010      488d05015001.  lea rax, 0x140016018       ; u"\twide\\esc: \033[0m\241\r\n"
 '
 run_test
 


### PR DESCRIPTION
Fixed tests for radare/radare2#7837.