### PR TITLE
Fix thumb ldr pc-relative tests

### DIFF
--- a/t.anal/arm/arm_16
+++ b/t.anal/arm/arm_16
@@ -12,18 +12,20 @@ run_test
 
 NAME="thumb ldr pc-rel analysis"
 FILE=malloc://32
+BROKEN=1
 CMDS="
 e asm.arch=arm
 e asm.bits=16
 wx dff80000 12000000 34000000
 pd 1
 "
-EXPECT='            0x00000000      dff80000       ldr.w r0, [0x00000008]      ; [0x8:4]=52 ; 8
+EXPECT='            0x00000000      dff80000       ldr.w r0, [0x00000008]      ; [0x4:4]=18 ; 4
 '
 run_test
 
 NAME="thumb ldr pc-rel emulation"
 FILE=malloc://32
+BROKEN=1
 CMDS="
 e asm.arch=arm
 e asm.bits=16
@@ -31,7 +33,7 @@ wx dff80000 12000000 34000000
 aes
 dr r0
 "
-EXPECT='0x00000034
+EXPECT='0x00000012
 '
 run_test
 


### PR DESCRIPTION
Fixed to reflect this fact: in THUMB mode all pc-relative loads have an offset if 4 bytes, regardless of the size of the instruction.

This test is now broken because of this: https://github.com/radare/radare2/blame/master/libr/anal/p/anal_arm_cs.c#L1338

Instead i observed that the above commented "theory" calculation of `pcdelta` should be used instead. (assuming that `thumb` flag is passed correctly to anal, ofc.) /cc @alvarofe 