### PR TITLE
Add quotes to "count grep" test name

### DIFF
--- a/t/feat_grep
+++ b/t/feat_grep
@@ -204,7 +204,7 @@ EXPECT='1020
 
 run_test
 
-NAME=count grep
+NAME='count grep'
 CMDS='
 wx 10203040
 b 128


### PR DESCRIPTION
Without quotes, the following usage message is shown:
```
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.
```