### PR TITLE
mdmp: moved mdmp to the core hence moved the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ anal.8051:
 esil:
 	$(SHELL) run_tests.sh t.esil
 
-formats: format.bflt format.coff format.smd format.vsf format.dex format.elf format.firmware format.java format.mach0 format.mangling format.msil format.omf format.others format.pdb format.pe format.xbe format.zimg format.nes format.gba format.wasm
+formats: format.bflt format.coff format.smd format.vsf format.dex format.elf format.firmware format.java format.mach0 format.mangling format.mdmp format.msil format.omf format.others format.pdb format.pe format.xbe format.zimg format.nes format.gba format.wasm
 format.vsf:
 	$(SHELL) run_tests.sh t.formats/vsf
 format.smd:
@@ -114,6 +114,8 @@ format.mach0:
 	$(SHELL) run_tests.sh t.formats/mach0
 format.mangling:
 	$(SHELL) run_tests.sh t.formats/mangling
+format.mdmp:
+	$(SHELL) run_tests.sh t.formats/mdmp
 format.msil:
 	$(SHELL) run_tests.sh t.formats/msil
 format.omf:
@@ -162,9 +164,6 @@ swf:
 
 m68k-extras:
 	$(SHELL) run_tests.sh t.extras/m68k
-
-extras.mdmp:
-	$(SHELL) run_tests.sh t.extras/mdmp
 
 olly-extras:
 	$(SHELL) run_tests.sh t.extras/x86_olly

--- a/t.formats/mdmp/mdmp
+++ b/t.formats/mdmp/mdmp
@@ -91,6 +91,34 @@ EXPECT='- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
 run_test
 
 
+NAME="${PLUGIN}: test format definitions"
+FILE=$F1
+ARGS='-nn'
+CMDS='pf.
+'
+EXPECT='pf.mdmp_memory_descriptor q? StartOfMemoryRange (mdmp_location_descriptor)Memory
+pf.mdmp_misc_info d[4]Bdtttddddd SizeOfInfo (mdmp_misc1_flags)Flags1 ProcessId ProcessCreateTime ProcessUserTime ProcessKernelTime ProcessorMaxMhz ProcessorCurrentMhz ProcessorMhzLimit ProcessorMaxIdleState ProcessorCurrentIdleState
+pf.mdmp_thread_list d[1]? NumberOfThreads (mdmp_thread)Threads
+pf.mdmp_module qddtd???qq BaseOfImage SizeOfImage CheckSum TimeDateStamp ModuleNameRVA (mdmp_vs_fixedfileinfo)VersionInfo (mdmp_location_descriptor)CvRecord (mdmp_location_descriptor)MiscRecord Reserved0 Reserved1
+pf.mdmp_system_info [2]EwwbBddd[4]Ed[2]Ew[2]q (mdmp_processor_architecture)ProcessorArchitecture ProcessorLevel ProcessorRevision NumberOfProcessors (mdmp_product_type)ProductType MajorVersion MinorVersion BuildNumber (mdmp_platform_id)PlatformId CsdVersionRva (mdmp_suite_mask)SuiteMask Reserved2 ProcessorFeatures
+pf.mdmp_exception [4]E[4]Eqqdd[15]q (mdmp_exception_code)ExceptionCode (mdmp_exception_flags)ExceptionFlags ExceptionRecord ExceptionAddress NumberParameters __UnusedAlignment ExceptionInformation
+pf.mdmp_module_list d[10]? NumberOfModule (mdmp_module)Modules
+pf.mdmp_location_descriptor dd DataSize RVA
+pf.mdmp_string dZ Length Buffer
+pf.mdmp_memory64_list qq[83]? NumberOfMemoryRanges BaseRva (mdmp_memory_descriptor64)MemoryRanges
+pf.mdmp_vs_fixedfileinfo ddddddddddddd dwSignature dwStrucVersion dwFileVersionMs dwFileVersionLs dwProductVersionMs dwProductVersionLs dwFileFlagsMask dwFileFlags dwFileOs dwFileType dwFileSubtype dwFileDateMs dwFileDateLs
+pf.mdmp_location_descriptor64 qq DataSize RVA
+pf.mdmp_header [4]zddddt[8]B Signature Version NumberOfStreams StreamDirectoryRVA CheckSum TimeDateStamp (mdmp_type)Flags
+pf.mdmp_exception_stream dd?? ThreadId __Alignment (mdmp_exception)ExceptionRecord (mdmp_location_descriptor)ThreadContext
+pf.mdmp_memory_descriptor64 qq StartOfMemoryRange DataSize
+pf.mdmp_directory [4]E? (mdmp_stream_type)StreamType (mdmp_location_descriptor)Location
+pf.mdmp_memory_info qq[4]Edq[4]E[4]E[4]Ed BaseAddress AllocationBase (mdmp_page_protect)AllocationProtect __Alignment1 RegionSize (mdmp_mem_state)State (mdmp_page_protect)Protect (mdmp_mem_type)Type __Alignment2
+pf.mdmp_thread ddddq?? ThreadId SuspendCount PriorityClass Priority Teb (mdmp_memory_descriptor)Stack (mdmp_location_descriptor)ThreadContext
+pf.mdmp_memory_info_list ddq[127]? SizeOfHeader SizeOfEntry NumberOfEntries (mdmp_memory_info)MemoryInfo
+'
+run_test
+
+
 NAME="${PLUGIN}: 32bit - libraries count"
 FILE=$F1
 ARGS=


### PR DESCRIPTION
Moved the tests to the correct location for the core and added to a test for `pf.` (as requested).