### PR TITLE
Tests whether no ESIL string is displayed for jmp (x86) and cbz (AArch64)

### DIFF
--- a/t.esil/arm-64
+++ b/t.esil/arm-64
@@ -733,8 +733,10 @@ NAME='no esil string on cbz'
 ARGS=
 CMDS='e asm.arch=arm
 e asm.bits=64
+e cfg.bigendian=false
 e asm.emustr=true
-wx 35008052b5000034
+wv 0x52800035
+wv 0x340000b5 @ 4
 w hello @ 0x18
 pd 2
 '

--- a/t.esil/arm-64
+++ b/t.esil/arm-64
@@ -728,3 +728,17 @@ EXPECT='0x00000000
 0x00000000
 '
 run_test
+
+NAME='no esil string on cbz'
+ARGS=
+CMDS='e asm.arch=arm
+e asm.bits=64
+e asm.emustr=true
+wx 35008052b5000034
+w hello @ 0x18
+pd 2
+'
+EXPECT='            0x00000000      35008052       movz w21, 0x1               
+        ,=< 0x00000004      b5000034       cbz w21, 0x18               ; likely
+'
+run_test

--- a/t.esil/x86-32
+++ b/t.esil/x86-32
@@ -1177,6 +1177,19 @@ EXPECT='TMCTF{datalosswontstopus}
 '
 run_test
 
+NAME='no esil string on jmp'
+ARGS=
+CMDS='e asm.arch=x86
+e asm.bits=32
+e asm.emustr=true
+wa jmp 0x100
+w hello @ 0x100
+pd 1
+'
+EXPECT='        ,=< 0x00000000      e9fb000000     jmp 0x100                   
+'
+run_test
+
 test_cmov() {
 NAME="${2} ${1}"
 if [ "${4}" = "br" ]; then


### PR DESCRIPTION
Tests based on specific cases from @radare.