### PR TITLE
Fix expected x86 assembler result for a 64-bit immediate mov to mem

### DIFF
--- a/new/db/asm/x86_64
+++ b/new/db/asm/x86_64
@@ -91,7 +91,9 @@ a "repne sfence" f20faef8
 a "rep rdpmc" f30f33
 a "mov eax, 33" b821000000
 a "mov rax, 33" 48c7c021000000
-a "mov [rbp+4],0" c7450400000000
+a "mov dword ptr [rbp+4],0" 67c7450400000000
+a "mov qword ptr [rbp+4],0" 48c7450400000000
+a "mov [rbp+4],0" 48c7450400000000
 a "mov [ebp+4],0" 67c7450400000000
 ad "push r8" 4150
 ad "push r9" 4151


### PR DESCRIPTION
In anticipation of a PR for https://github.com/radare/radare2/issues/8939.

> Unless we explicitly override the operand size with e.g. a `dword ptr` qualifier, we should emit an instruction with a REX prefix of 0x48 (W bit set) to indicate a 64-bit operand.

In reality, there's room for debate: other assemblers consider the case `mov [rbp+4], 0` to be ambiguous, and _require_ an operand size qualifier. In rasm, we seem to allow this ambiguity. My existing patch (https://github.com/ranweiler/radare2/commit/25295d42fb782f33b6d5f37913a3e2b1bdb6d3ff, which adds the 0x48 prefix) is only hit if `bits == 64` and we've already flagged the operand as 64-bit, in which case I think it is appropriate to expect an unqualified `mov` to memory to assemble as if we included `qword ptr`.

I'm open to other ideas, but short of a larger refactoring, I think this is a consistent improvement on the assembler output in this case.