### PR TITLE
Fixing expected strings for pr #8972 radare2

### DIFF
--- a/t/cmd_pd
+++ b/t/cmd_pd
@@ -633,10 +633,10 @@ pd 1 @ 0x0001145f
 e asm.cmtright=false
 pd 1 @ 0x0001145f
 '
-EXPECT='            0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call._n ; 0x1b5d8 ; "A NULL argv[0] was passed through an exec system call.\n"
+EXPECT='            0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call.__ ; 0x1b5d8 ; "A NULL argv[0] was passed through an exec system call.\n"
                ; 0x1b5d8
                ; "A NULL argv[0] was passed through an exec system call.\n"
-            0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call._n
+            0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call.__
 '
 run_test
 
@@ -665,10 +665,10 @@ pd 1 @ 0x004010f0
 e asm.cmtright=false
 pd 1 @ 0x004010f0
 '
-EXPECT='            0x004010f0      68b8214000     push str.Number_of_CPU__d_n ; 0x4021b8 ; u"Number of CPU %d\n"
+EXPECT='            0x004010f0      68b8214000     push str.Number_of_CPU__d__ ; 0x4021b8 ; u"Number of CPU %d\n"
                ; 0x4021b8
                ; u"Number of CPU %d\n"
-            0x004010f0      68b8214000     push str.Number_of_CPU__d_n
+            0x004010f0      68b8214000     push str.Number_of_CPU__d__
 '
 run_test
 
@@ -731,7 +731,7 @@ pd 1 @ 0x0001145f
 e asm.filter=false
 pd 1 @ 0x0001145f
 '
-EXPECT='  [36m          [0m[32m0x0001145f[0m      [37mlea[36m rdi[0m,[36m[36m [33mstr.A_NULL_argv_0__was_passed_through_an_exec_system_call._n[0m[0m
+EXPECT='  [36m          [0m[32m0x0001145f[0m      [37mlea[36m rdi[0m,[36m[36m [33mstr.A_NULL_argv_0__was_passed_through_an_exec_system_call.__[0m[0m
   [36m          [0m[32m0x0001145f[0m      [37mlea[36m rdi[0m,[36m[36m [33m0x0001b5d8[0m[0m
 '
 run_test
@@ -748,16 +748,16 @@ pd 1 @ 0x140001004
 pd 1 @ 0x140001010
 pd 1 @ 0x14000101c
 '
-EXPECT='            0x140001004      488d05f54f01.  lea rax, str._tANSI__esc:__e_33m_r_n ; section..data ; 0x140016000 ; "\tANSI\\esc: \x1b[33m\r\n"
-            0x140001010      488d05015001.  lea rax, str._twide__esc:__e_0m___r_n ; 0x140016018 ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+EXPECT='            0x140001004      488d05f54f01.  lea rax, str.__ANSI__esc:__e_33m____ ; section..data ; 0x140016000 ; "\tANSI\\esc: \x1b[33m\r\n"
+            0x140001010      488d05015001.  lea rax, str.__wide__esc:__e_0m______ ; 0x140016018 ; u"\twide\\esc: \x1b[0m\xa1\r\n"
             0x14000101c      488d051d5001.  lea rax, str._wide__in_Arabic:_________ ; 0x140016040 ; u"\"wide\" in Arabic: \u0648\u0627\u0633\u0639"
                ; section..data
                ; 0x140016000
                ; "\tANSI\\esc: \x1b[33m\r\n"
-            0x140001004      488d05f54f01.  lea rax, str._tANSI__esc:__e_33m_r_n
+            0x140001004      488d05f54f01.  lea rax, str.__ANSI__esc:__e_33m____
                ; 0x140016018
                ; u"\twide\\esc: \x1b[0m\xa1\r\n"
-            0x140001010      488d05015001.  lea rax, str._twide__esc:__e_0m___r_n
+            0x140001010      488d05015001.  lea rax, str.__wide__esc:__e_0m______
                ; 0x140016040
                ; u"\"wide\" in Arabic: \u0648\u0627\u0633\u0639"
             0x14000101c      488d051d5001.  lea rax, str._wide__in_Arabic:_________
@@ -865,7 +865,7 @@ EXPECT='            0x004016ac      mov edi, 0x40224a                          ;
             0x004016c0      mov edi, str._B_                           ; " %B%"
             0x004016c0      mov edi, str._B_                           ; u"\u2520\u2542\u2500\u2500\u2542\u2528 is a fence with embedded zeros\n"
             0x004016ca      mov edi, str._B__                          ; u"\u2520\u2542-\u2500-\u2500\u2542\u2528 is a fence with embedded double zeros\n"
-            0x004016d4      mov edi, str.e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k__n ; u"\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565"
+            0x004016d4      mov edi, str.e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k___ ; u"\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565"
 '
 run_test
 
@@ -887,8 +887,8 @@ pd 1 @ 0x00401701
 e asm.strenc=utf32le
 pd 1 @ 0x00401701
 '
-EXPECT='            0x004016de      mov esi, str._tLinux_wide__esc:__e_0m___r_n ; u"\t"
-            0x004016de      mov esi, str._tLinux_wide__esc:__e_0m___r_n ; U"\tLinux_wide\\esc: \x1b[0m\xa1\r\n"
+EXPECT='            0x004016de      mov esi, str.__Linux_wide__esc:__e_0m______ ; u"\t"
+            0x004016de      mov esi, str.__Linux_wide__esc:__e_0m______ ; U"\tLinux_wide\\esc: \x1b[0m\xa1\r\n"
             0x004016ed      mov edi, 0x40258c                          ; U"utf32le> \\u00a2\\u20ac\\U00010348 in cyan:\x1b[36m \xa2\u20ac\U00010348 \x1b[0m\n"
             0x004016f7      mov edi, 0x40266c                          ; U"Mountain range with embedded quad zeros: \U00010300A\U00010300A\U00010300A\n"
             0x00401701      mov edi, 0x402730                          ; "e%"
@@ -937,17 +937,17 @@ pd 1 @ 0x140001028
 e asm.cmtright=false
 pd 1 @ 0x140001010
 pd 1 @ 0x140001028
-fr str._twide__esc:__e_0m___r_n str.wide
+fr str.__wide__esc:__e_0m______ str.wide
 e asm.cmtright=true
 pd 1 @ 0x140001010
 e asm.cmtright=false
 pd 1 @ 0x140001010
 '
 EXPECT='            0x140001010      488d05015001.  lea rax, 0x140016018       ; u"\twide\\esc: \x1b[0m\xa1\r\n"
-            0x140001028      488d05415001.  lea rax, 0x140016070       ; str._fFormfeed_at_start
+            0x140001028      488d05415001.  lea rax, 0x140016070       ; str.__Formfeed_at_start
                ; u"\twide\\esc: \x1b[0m\xa1\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018
-               ; str._fFormfeed_at_start
+               ; str.__Formfeed_at_start
             0x140001028      488d05415001.  lea rax, 0x140016070
             0x140001010      488d05015001.  lea rax, 0x140016018       ; str.wide ; u"\twide\\esc: \x1b[0m\xa1\r\n"
                ; str.wide
@@ -966,8 +966,8 @@ pd 1 @ 0x140001010
 e asm.cmtright=false
 pd 1 @ 0x140001010
 '
-EXPECT='            0x140001010      488d05015001.  lea rax, 0x140016018       ; str._twide__esc:__e_0m___r_n ; u"\twide\\esc: \x1b[0m\xa1\r\n"
-               ; str._twide__esc:__e_0m___r_n
+EXPECT='            0x140001010      488d05015001.  lea rax, 0x140016018       ; str.__wide__esc:__e_0m______ ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+               ; str.__wide__esc:__e_0m______
                ; u"\twide\\esc: \x1b[0m\xa1\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018
 '
@@ -1013,7 +1013,7 @@ pd 1 @ 0x140001010
 e asm.cmtoff=nodup
 pd 1 @ 0x140001010
 '
-EXPECT='            0x140001010      488d05015001.  lea rax, str._twide__esc:__e_0m___r_n ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+EXPECT='            0x140001010      488d05015001.  lea rax, str.__wide__esc:__e_0m______ ; u"\twide\\esc: \x1b[0m\xa1\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018       ; 0x140016018 ; u"\twide\\esc: \x1b[0m\xa1\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018       ; u"\twide\\esc: \x1b[0m\xa1\r\n"
 '

--- a/t/cmd_pd
+++ b/t/cmd_pd
@@ -633,10 +633,10 @@ pd 1 @ 0x0001145f
 e asm.cmtright=false
 pd 1 @ 0x0001145f
 '
-EXPECT='            0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call.__ ; 0x1b5d8 ; "A NULL argv[0] was passed through an exec system call.\n"
+EXPECT='            0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call. ; 0x1b5d8 ; "A NULL argv[0] was passed through an exec system call.\n"
                ; 0x1b5d8
                ; "A NULL argv[0] was passed through an exec system call.\n"
-            0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call.__
+            0x0001145f      488d3d72a100.  lea rdi, str.A_NULL_argv_0__was_passed_through_an_exec_system_call.
 '
 run_test
 
@@ -665,10 +665,10 @@ pd 1 @ 0x004010f0
 e asm.cmtright=false
 pd 1 @ 0x004010f0
 '
-EXPECT='            0x004010f0      68b8214000     push str.Number_of_CPU__d__ ; 0x4021b8 ; u"Number of CPU %d\n"
+EXPECT='            0x004010f0      68b8214000     push str.Number_of_CPU__d   ; 0x4021b8 ; u"Number of CPU %d\n"
                ; 0x4021b8
                ; u"Number of CPU %d\n"
-            0x004010f0      68b8214000     push str.Number_of_CPU__d__
+            0x004010f0      68b8214000     push str.Number_of_CPU__d
 '
 run_test
 
@@ -731,7 +731,7 @@ pd 1 @ 0x0001145f
 e asm.filter=false
 pd 1 @ 0x0001145f
 '
-EXPECT='  [36m          [0m[32m0x0001145f[0m      [37mlea[36m rdi[0m,[36m[36m [33mstr.A_NULL_argv_0__was_passed_through_an_exec_system_call.__[0m[0m
+EXPECT='  [36m          [0m[32m0x0001145f[0m      [37mlea[36m rdi[0m,[36m[36m [33mstr.A_NULL_argv_0__was_passed_through_an_exec_system_call.[0m[0m
   [36m          [0m[32m0x0001145f[0m      [37mlea[36m rdi[0m,[36m[36m [33m0x0001b5d8[0m[0m
 '
 run_test
@@ -748,19 +748,19 @@ pd 1 @ 0x140001004
 pd 1 @ 0x140001010
 pd 1 @ 0x14000101c
 '
-EXPECT='            0x140001004      488d05f54f01.  lea rax, str.__ANSI__esc:__e_33m____ ; section..data ; 0x140016000 ; "\tANSI\\esc: \x1b[33m\r\n"
-            0x140001010      488d05015001.  lea rax, str.__wide__esc:__e_0m______ ; 0x140016018 ; u"\twide\\esc: \x1b[0m\xa1\r\n"
-            0x14000101c      488d051d5001.  lea rax, str._wide__in_Arabic:_________ ; 0x140016040 ; u"\"wide\" in Arabic: \u0648\u0627\u0633\u0639"
+EXPECT='            0x140001004      488d05f54f01.  lea rax, str.ANSI__esc:__e_33m ; section..data ; 0x140016000 ; "\tANSI\\esc: \x1b[33m\r\n"
+            0x140001010      488d05015001.  lea rax, str.wide__esc:__e_0m ; 0x140016018 ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+            0x14000101c      488d051d5001.  lea rax, str.wide__in_Arabic: ; 0x140016040 ; u"\"wide\" in Arabic: \u0648\u0627\u0633\u0639"
                ; section..data
                ; 0x140016000
                ; "\tANSI\\esc: \x1b[33m\r\n"
-            0x140001004      488d05f54f01.  lea rax, str.__ANSI__esc:__e_33m____
+            0x140001004      488d05f54f01.  lea rax, str.ANSI__esc:__e_33m
                ; 0x140016018
                ; u"\twide\\esc: \x1b[0m\xa1\r\n"
-            0x140001010      488d05015001.  lea rax, str.__wide__esc:__e_0m______
+            0x140001010      488d05015001.  lea rax, str.wide__esc:__e_0m
                ; 0x140016040
                ; u"\"wide\" in Arabic: \u0648\u0627\u0633\u0639"
-            0x14000101c      488d051d5001.  lea rax, str._wide__in_Arabic:_________
+            0x14000101c      488d051d5001.  lea rax, str.wide__in_Arabic:
 '
 run_test
 
@@ -860,12 +860,12 @@ pd 1 @ 0x004016ca
 pd 1 @ 0x004016d4
 '
 EXPECT='            0x004016ac      mov edi, 0x40224a                          ; u"utf16le> \\u00a2\\u20ac\\U00010348 in green:\x1b[32m \xa2\u20ac\U00010348 \x1b[0m\n"
-            0x004016b6      mov edi, str.__e_e_b_                      ; "_%e%e%b% "
-            0x004016b6      mov edi, str.__e_e_b_                      ; u"\u255f\u2565\u2565\u2562 is a wall with no embedded zeros\n"
-            0x004016c0      mov edi, str._B_                           ; " %B%"
-            0x004016c0      mov edi, str._B_                           ; u"\u2520\u2542\u2500\u2500\u2542\u2528 is a fence with embedded zeros\n"
-            0x004016ca      mov edi, str._B__                          ; u"\u2520\u2542-\u2500-\u2500\u2542\u2528 is a fence with embedded double zeros\n"
-            0x004016d4      mov edi, str.e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k___ ; u"\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565"
+            0x004016b6      mov edi, str.e_e_b                         ; "_%e%e%b% "
+            0x004016b6      mov edi, str.e_e_b                         ; u"\u255f\u2565\u2565\u2562 is a wall with no embedded zeros\n"
+            0x004016c0      mov edi, 0x40230c                          ; " %B%"
+            0x004016c0      mov edi, 0x40230c                          ; u"\u2520\u2542\u2500\u2500\u2542\u2528 is a fence with embedded zeros\n"
+            0x004016ca      mov edi, 0x40235a                          ; u"\u2520\u2542-\u2500-\u2500\u2542\u2528 is a fence with embedded double zeros\n"
+            0x004016d4      mov edi, str.e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k_e_e_e_e_e_e_e_e_e_k ; u"\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u2565\u256b\u2565\u2565\u2565\u2565\u2565"
 '
 run_test
 
@@ -887,8 +887,8 @@ pd 1 @ 0x00401701
 e asm.strenc=utf32le
 pd 1 @ 0x00401701
 '
-EXPECT='            0x004016de      mov esi, str.__Linux_wide__esc:__e_0m______ ; u"\t"
-            0x004016de      mov esi, str.__Linux_wide__esc:__e_0m______ ; U"\tLinux_wide\\esc: \x1b[0m\xa1\r\n"
+EXPECT='            0x004016de      mov esi, str.Linux_wide__esc:__e_0m        ; u"\t"
+            0x004016de      mov esi, str.Linux_wide__esc:__e_0m        ; U"\tLinux_wide\\esc: \x1b[0m\xa1\r\n"
             0x004016ed      mov edi, 0x40258c                          ; U"utf32le> \\u00a2\\u20ac\\U00010348 in cyan:\x1b[36m \xa2\u20ac\U00010348 \x1b[0m\n"
             0x004016f7      mov edi, 0x40266c                          ; U"Mountain range with embedded quad zeros: \U00010300A\U00010300A\U00010300A\n"
             0x00401701      mov edi, 0x402730                          ; "e%"
@@ -937,17 +937,17 @@ pd 1 @ 0x140001028
 e asm.cmtright=false
 pd 1 @ 0x140001010
 pd 1 @ 0x140001028
-fr str.__wide__esc:__e_0m______ str.wide
+fr str.wide__esc:__e_0m str.wide
 e asm.cmtright=true
 pd 1 @ 0x140001010
 e asm.cmtright=false
 pd 1 @ 0x140001010
 '
 EXPECT='            0x140001010      488d05015001.  lea rax, 0x140016018       ; u"\twide\\esc: \x1b[0m\xa1\r\n"
-            0x140001028      488d05415001.  lea rax, 0x140016070       ; str.__Formfeed_at_start
+            0x140001028      488d05415001.  lea rax, 0x140016070       ; str.Formfeed_at_start
                ; u"\twide\\esc: \x1b[0m\xa1\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018
-               ; str.__Formfeed_at_start
+               ; str.Formfeed_at_start
             0x140001028      488d05415001.  lea rax, 0x140016070
             0x140001010      488d05015001.  lea rax, 0x140016018       ; str.wide ; u"\twide\\esc: \x1b[0m\xa1\r\n"
                ; str.wide
@@ -966,8 +966,8 @@ pd 1 @ 0x140001010
 e asm.cmtright=false
 pd 1 @ 0x140001010
 '
-EXPECT='            0x140001010      488d05015001.  lea rax, 0x140016018       ; str.__wide__esc:__e_0m______ ; u"\twide\\esc: \x1b[0m\xa1\r\n"
-               ; str.__wide__esc:__e_0m______
+EXPECT='            0x140001010      488d05015001.  lea rax, 0x140016018       ; str.wide__esc:__e_0m ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+               ; str.wide__esc:__e_0m
                ; u"\twide\\esc: \x1b[0m\xa1\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018
 '
@@ -1013,7 +1013,7 @@ pd 1 @ 0x140001010
 e asm.cmtoff=nodup
 pd 1 @ 0x140001010
 '
-EXPECT='            0x140001010      488d05015001.  lea rax, str.__wide__esc:__e_0m______ ; u"\twide\\esc: \x1b[0m\xa1\r\n"
+EXPECT='            0x140001010      488d05015001.  lea rax, str.wide__esc:__e_0m ; u"\twide\\esc: \x1b[0m\xa1\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018       ; 0x140016018 ; u"\twide\\esc: \x1b[0m\xa1\r\n"
             0x140001010      488d05015001.  lea rax, 0x140016018       ; u"\twide\\esc: \x1b[0m\xa1\r\n"
 '
@@ -1078,7 +1078,7 @@ ARGS=
 CMDS='e asm.bytes=false
 pd 1 @ 0x004004ee
 '
-EXPECT='            0x004004ee      mov edi, str._____S                        ; 0x4005c0 ; u"\ufeff--> %S\ufeff\n"
+EXPECT='            0x004004ee      mov edi, str.S                             ; 0x4005c0 ; u"\ufeff--> %S\ufeff\n"
 '
 run_test
 

--- a/t/cmd_pd_bugs
+++ b/t/cmd_pd_bugs
@@ -9,7 +9,7 @@ CMDS='
 e asm.lines=0
 e asm.bytes=0
 e asm.comments=0
-s sym.__Test_callMeNot_
+s sym.__Test_callMeNot
 pd 20~?NSLog
 af
 pd 20~?NSLog
@@ -50,7 +50,7 @@ CMDS='
 e asm.lines=0
 e asm.bytes=0
 e asm.comments=0
-s sym.__Test_callMeNot_
+s sym.__Test_callMeNot
 # s+2
 pi 2
 '


### PR DESCRIPTION
special chars in like /n, /t, etc. are removed in str flags in regression tests