### PR TITLE
Fix test for imul 1 arg in x86-64

### DIFF
--- a/t.esil/x86-64
+++ b/t.esil/x86-64
@@ -11,7 +11,7 @@ e asm.bits=64
 .(pi 49f7e9)
 '
 EXPECT='imul r9
-0x00000000 r9,rax,*=
+0x00000000 64,r9,rax,*,>>,rdx,=,r9,rax,*=
 '
 run_test
 


### PR DESCRIPTION
Related to #9647 in radare2 repo.