### PR TITLE
Support <<-type multiline tests

### DIFF
--- a/new/bin/r2r.js
+++ b/new/bin/r2r.js
@@ -264,23 +264,44 @@ function fixTest (test, next) {
     let target = null;
     const stateEnum = Object.freeze({NORMAL: 0, EXPECT_CONT: 1});
     var state = stateEnum.NORMAL;
-    var delim;
+    var delim = null;
+    var endString = null;
     for (let line of lines) {
       if (target) {
         if (state === stateEnum.EXPECT_CONT) {
-          const endDelim = line.indexOf(delim);
-          if (endDelim !== -1) {
-            output += 'EXPECT=' + delim + test.stdout + delim + '\n';
-            state = stateEnum.NORMAL;
+          if (delim !== null) {
+            const endDelim = line.indexOf(delim);
+            if (endDelim !== -1) {
+              output += 'EXPECT=' + delim + test.stdout + delim + '\n';
+              state = stateEnum.NORMAL;
+            }
+            continue;
+          } else if (endString !== null) {
+            if (line.startsWith(endString)) {
+              output += 'EXPECT=<<' + endString + '\n' + test.stdout;
+              state = stateEnum.NORMAL;
+              // no continue
+            } else {
+              continue;
+            }
+          } else {
+            throw new Error('Internal error, EXPECT_CONT');
           }
-          continue;
         }
         if (line.startsWith('EXPECT64=')) {
           const msg = Buffer.from(test.stdout).toString('base64');
           output += 'EXPECT64=' + msg + '\n';
         } else if (line.startsWith('EXPECT=')) {
-          const val = line.substring(7)
-          var delim = val.trim().charAt(0);
+          delim = null;
+          endString = null;
+          const val = line.substring(7);
+          const valTrim = val.trim();
+          if (valTrim.startsWith('<<')) {
+            endString = valTrim.substring(2);
+            state = stateEnum.EXPECT_CONT;
+            continue;
+          }
+          delim = valTrim.charAt(0);
           if (delims.test(delim)) {
             const startDelim = val.indexOf(delim);
             const endDelim = val.indexOf(delim, startDelim + 1);
@@ -331,22 +352,39 @@ function fixCommands (test, next) {
     var msg;
     const stateEnum = Object.freeze({NORMAL: 0, CMDS_CONT: 1});
     var state = stateEnum.NORMAL;
-    var delim;
+    var delim = null;
+    var endString = null;
     for (let line of lines) {
       if (target) {
         if (state === stateEnum.CMDS_CONT) {
-          const endDelim = line.indexOf(delim);
-          if (endDelim == -1) {
-            msg += line + '\n';
+          if (delim !== null) {
+            const endDelim = line.indexOf(delim);
+            if (endDelim == -1) {
+              msg += line + '\n';
+            } else {
+              msg += line.substring(0, endDelim);
+              fs.writeFileSync('.cmds.txt', msg);
+              editFile('.cmds.txt');
+              const cmds = fs.readFileSync('.cmds.txt').toString();
+              output += 'CMDS=' + delim + cmds + delim + '\n';
+              state = stateEnum.NORMAL;
+            }
+            continue;
+          } else if (endString !== null) {
+            if (line.startsWith(endString)) {
+              fs.writeFileSync('.cmds.txt', msg);
+              editFile('.cmds.txt');
+              const cmds = fs.readFileSync('.cmds.txt').toString();
+              output += 'CMDS=<<' + endString + '\n' + cmds;
+              state = stateEnum.NORMAL;
+              // no continue
+            } else {
+              msg += line + '\n';
+              continue;
+            }
           } else {
-            msg += line.substring(0, endDelim);
-            fs.writeFileSync('.cmds.txt', msg);
-            editFile('.cmds.txt');
-            const cmds = fs.readFileSync('.cmds.txt').toString();
-            output += 'CMDS=' + delim + cmds + delim + '\n';
-            state = stateEnum.NORMAL;
+            throw new Error('Internal error, CMDS_CONT');
           }
-          continue;
         }
         if (line.startsWith('CMDS64=')) {
           msg = Buffer.from(line.substring(7), 'base64');
@@ -355,8 +393,17 @@ function fixCommands (test, next) {
           const cmds = fs.readFileSync('.cmds.txt').toString('base64');
           output += 'CMDS64=' + cmds + '\n';
         } else if (line.startsWith('CMDS=')) {
+          delim = null;
+          endString = null;
           const val = line.substring(5);
-          delim = val.trim().charAt(0);
+          const valTrim = val.trim();
+          if (valTrim.startsWith('<<')) {
+            endString = valTrim.substring(2);
+            msg = '';
+            state = stateEnum.CMDS_CONT;
+            continue;
+          }
+          delim = valTrim.charAt(0);
           if (delims.test(delim)) {
             const startDelim = val.indexOf(delim);
             const endDelim = val.indexOf(delim, startDelim + 1);

--- a/new/db/cmd/feat_input
+++ b/new/db/cmd/feat_input
@@ -66,19 +66,19 @@ EXPECT64=Li0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0uCnwgIFByb2Nlc3MgZm9ybSBBIyB
 RUN
 NAME=cmd outputting trailing space
 FILE=-
-CMDS='# do not convert test to base64
+CMDS=<<EXPECT
+# do not convert test to base64
 ?e aaa
 "?e bbb  "
 ?e ccc
 "?e ddd     "
 ?e eee
 "?e fff        "
-'
-EXPECT='aaa
+EXPECT=<<RUN
+aaa
 bbb  
 ccc
 ddd     
 eee
 fff        
-'
 RUN

--- a/new/index.js
+++ b/new/index.js
@@ -305,29 +305,54 @@ class NewRegressions {
     const delims = /['"%]/;
     const stateEnum = Object.freeze({NORMAL: 0, CMDS_CONT: 1, EXPECT_CONT: 2});
     var state = stateEnum.NORMAL;
-    var delim;
+    var delim = null;
+    var endString = null;
     var endDelim;
     for (let l of lines) {
       switch (state) {
         case stateEnum.CMDS_CONT:
-          endDelim = l.indexOf(delim);
-          if (endDelim == -1) {
-            test.cmdScript += l + "\n";
+          if (delim !== null) {
+            endDelim = l.indexOf(delim);
+            if (endDelim == -1) {
+              test.cmdScript += l + '\n';
+            } else {
+              test.cmdScript += l.substring(0, endDelim);
+              test.cmds = test.cmdScript.trim().split('\n');
+              state = stateEnum.NORMAL;
+            }
+            continue;
+          } else if (endString !== null) {
+            if (l.startsWith(endString)) {
+              state = stateEnum.NORMAL;
+              break; // not continue
+            } else {
+              test.cmdScript += l + '\n';
+              continue;
+            }
           } else {
-            test.cmdScript += l.substring(0, endDelim);
-            test.cmds = test.cmdScript.trim().split('\n');
-            state = stateEnum.NORMAL;
+            throw new Error('Internal error, CMDS_CONT');
           }
-          continue;
         case stateEnum.EXPECT_CONT:
-          endDelim = l.indexOf(delim);
-          if (endDelim == -1) {
-            test.expect += l + "\n";
+          if (delim !== null) {
+            endDelim = l.indexOf(delim);
+            if (endDelim == -1) {
+              test.expect += l + '\n';
+            } else {
+              test.expect += l.substring(0, endDelim);
+              state = stateEnum.NORMAL;
+            }
+            continue;
+          } else if (endString !== null) {
+            if (l.startsWith(endString)) {
+              state = stateEnum.NORMAL;
+              break; // not continue
+            } else {
+              test.expect += l + '\n';
+              continue;
+            }
           } else {
-            test.expect += l.substring(0, endDelim);
-            state = stateEnum.NORMAL;
+            throw new Error('Internal error, EXPECT_CONT');
           }
-          continue;
       }
       const line = l.trim();
       if (line.length === 0 || line[0] === '#') {
@@ -363,6 +388,7 @@ class NewRegressions {
       }
       const k = l.substring(0, eq);
       const v = l.substring(eq + 1);
+      const vt = v.trim();
       switch (k) {
         case 'NAME':
           test.name = v;
@@ -377,7 +403,15 @@ class NewRegressions {
           test.args = v || [];
           break;
         case 'CMDS':
-          delim = v.trim().charAt(0);
+          delim = null;
+          endString = null;
+          if (vt.startsWith('<<')) {
+            endString = vt.substring(2);
+            test.cmdScript = '';
+            state = stateEnum.CMDS_CONT;
+            break;
+          }
+          delim = vt.charAt(0);
           if (delims.test(delim)) {
             const startDelim = v.indexOf(delim);
             const endDelim = v.indexOf(delim, startDelim + 1);
@@ -408,7 +442,16 @@ class NewRegressions {
           break;
         case 'EXPECT':
           test.expect64 = false;
-          delim = v.trim().charAt(0);
+          delim = null;
+          endString = null;
+          if (vt.startsWith('<<')) {
+            endString = vt.substring(2);
+            test.endString = endString;
+            test.expect = '';
+            state = stateEnum.EXPECT_CONT;
+            break;
+          }
+          delim = vt.charAt(0);
           if (delims.test(delim)) {
             test.expectDelim = delim;
             const startDelim = v.indexOf(delim);
@@ -577,10 +620,14 @@ class NewRegressions {
       if (test.expect64) {
         console.log('EXPECT64=' + base64(test.stdout));
       } else if (test.expect64 !== undefined) {
-        if (test.expectDelim === undefined) {
-          test.expectDelim = '%';
+        if (test.endString !== undefined) {
+          common.highlightTrailingWs(null, '\nEXPECT=<<' + test.endString + '\n' + test.stdout);
+        } else {
+          if (test.expectDelim === undefined) {
+            test.expectDelim = '%';
+          }
+          common.highlightTrailingWs(null, '\nEXPECT=' + test.expectDelim + test.stdout + test.expectDelim + '\n');
         }
-        common.highlightTrailingWs(null, '\nEXPECT=' + test.expectDelim + test.stdout + test.expectDelim + '\n');
       }
       if (this.interactive) {
 //        console.log('TODO: interactive thing should happen here');


### PR DESCRIPTION
As per new [README](https://github.com/radare/radare2-regressions/blob/718ffbe533e09b86bb789ae723b9ef9b6e4e4f55/new/README.md). (Only just recently realized that there is a README for the new r2r)

Useful if alignment of lines etc. is desired.