### PR TITLE
Removed shortcuts in non-interactive graph test

### DIFF
--- a/t.anal/others_anal/cmd_anal_fcn
+++ b/t.anal/others_anal/cmd_anal_fcn
@@ -272,7 +272,7 @@ agf
 k='`'
 EXPECT="[0x00000000]> VV @ fcn.test (nodes 1 edges 0 zoom 100%) BB-NORM mouse:canvas-y mov-speed:5
 .---------------------------.
-|  0x0 ;[ga]                |
+|  0x0                      |
 | / (fcn) fcn.test          |
 | (6 byte folded function)  |
 $k---------------------------'


### PR DESCRIPTION
Fixes a small test running `agf`

This fixes pr https://github.com/radare/radare2/pull/10187

Removes shortcuts since they are useless when the graph is non interactive.