### PR TITLE
Fix pdb-downloader not redirecting stderr to grep

### DIFF
--- a/t.formats/pdb/pdb
+++ b/t.formats/pdb/pdb
@@ -6,7 +6,7 @@ for a in . .. ../.. ; do [ -e $a/tests.sh ] && . $a/tests.sh ; done
 NAME='PDB downloader check'
 FILE=../../bins/pdb/user32.dll
 ARGS="-e pdb.server=http://radare.org/"
-CMDS='!rabin2 -PP ${R2_FILE} | grep PDB;rm user32.pdb'
+CMDS='!!rabin2 -PP ${R2_FILE} ~PDB'
 EXPECT='PDB "user32.pdb" download success
 '
 EXPECT_ERR=''


### PR DESCRIPTION
This fix should make master green again.

Unfortunately it seems that `!` command followed by a pipe `|` does't redirect stderr.

But changing it to `!!` and using `~` works correctly.