### PR TITLE
be more node standard

### DIFF
--- a/new/package.json
+++ b/new/package.json
@@ -3,6 +3,12 @@
   "version": "0.1.0",
   "description": "new testsuite for r2 written in nodejs",
   "main": "index.js",
+  "bin": {
+    "r2r": "bin/r2r.js"
+  },
+  "engines": {
+    "node": ">=8.x"
+  },
   "dependencies": {
     "co": "*",
     "colors": "^1.2.5",


### PR DESCRIPTION
You dont support under node 8
```
TypeError: promisify is not a function
    at Object.<anonymous> (/Users/jacobrosenthal/Downloads/radare2-regressions/new/index.js:9:21)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:389:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:504:3
```

So be explicit in the package.json with an engines field. And support npm link (and just manual understanding of what file is to be run) by using bin field