### PR TITLE
Add a minimum version of nodeJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Requirements
 
  * Radare2 installed (and in $PATH or set the R2 environment).
  * Valgrind (optional).
- * nodeJS
+ * nodeJS 8 or above
 
 Usage
 -----


### PR DESCRIPTION
Since it use util.promisify, it need node 8, which exclude
RHEL 7