### PR TITLE
Add tests for anal.jmpmid (x86, no loops)

### DIFF
--- a/new/db/anal/x86_2
+++ b/new/db/anal/x86_2
@@ -1,6 +1,7 @@
 NAME=r_anal_fcn_split_bb FITFCNSZ fix (#12008)
 FILE=-
 CMDS=<<EXPECT
+e anal.jmpmid=false
 e io.cache=true
 wx b8210000c1ebfdbb2c000000000
 af
@@ -27,4 +28,66 @@ size: 7
 |   fcn.00000000 ();
 |           0x00000000      b8210000c1     mov eax, 0xc1000021         ; '!'
 \       `=< 0x00000005      ebfd           jmp 4
+RUN
+
+NAME=overlapping basic blocks and anal.jmpmid (no loops)
+FILE=-
+CMDS=<<EXPECT
+e anal.jmpmid=true
+e io.cache=true
+e anal.endsize=false
+wx b8210000c1ebfdbb2c000000cc  # TODO: cc -> ebf6
+af
+afi~size
+afb
+?e
+pdr
+?e
+agf
+# Commented out because asm.bb.middle is broken in this case
+# ?e
+# e asm.bb.middle=true
+# pdf
+# ?e
+# e asm.bb.middle=false
+# pdf
+EXPECT=<<RUN
+size: 13
+0x00000000 0x00000007 00:0000 7 j 0x00000004
+0x00000004 0x0000000d 00:0000 9
+
+/ (fcn) fcn.00000000 16
+|   fcn.00000000 ();
+| ; CODE XREF from fcn.00000000 (0x5)
+| 0x00000000      b8210000c1     mov eax, 0xc1000021                   ; '!'
+| 0x00000005      ebfd           jmp 4
+| ----------- true: 0x00000004
+| ; CODE XREF from fcn.00000000 (0x5)
+| 0x00000004      c1ebfd         shr ebx, 0xfd
+| 0x00000007      bb2c000000     mov ebx, 0x2c                         ; ','
+\ 0x0000000c      cc             int3
+
+
+[0x00000000]> VV @ fcn.00000000 (nodes 2 edges 1 zoom 100%) BB-NORM mouse:canvas-y mov-speed:5
+.--------------------------------------.
+|  0x0                                 |
+| (fcn) fcn.00000000 16                |
+|   fcn.00000000 ();                   |
+| ; CODE XREF from fcn.00000000 (0x5)  |
+| ; '!'                                |
+| mov eax, 0xc1000021                  |
+| jmp 4;[ga]                           |
+`--------------------------------------'
+    v
+    |
+    '.
+     |
+ .-------------------------------------.
+ |  0x4                                |
+ | ; CODE XREF from fcn.00000000 (0x5) |
+ | shr ebx, 0xfd                       |
+ | ; ','                               |
+ | mov ebx, 0x2c                       |
+ | int3                                |
+ `-------------------------------------'
 RUN


### PR DESCRIPTION
Added tests for radare/radare2#12019.