### PR TITLE
Fixed the test for rasm -Aj

### DIFF
--- a/new/db/tools/rasm2
+++ b/new/db/tools/rasm2
@@ -348,8 +348,7 @@ RUN
 NAME=rasm2 -Aj 0x55
 FILE=-
 CMDS=!rasm2 -Aj 0x55
-EXPECT='[{"opcode":0,"bytes":"55","type":"upush","stackop":"unknown","esil":"rbp,8,rsp,-,=[8],8,rsp,-=","stackptr":8}
-]'
+EXPECT='[{"opcode":0,"bytes":"55","type":"upush","stackop":"unknown","esil":"rbp,8,rsp,-,=[8],8,rsp,-=","stackptr":8}]'
 RUN
 
 NAME=rasm2 -L


### PR DESCRIPTION
I changed the implementation a bit to remove the new line after the  }. 

For pr https://github.com/radare/radare2/pull/13025