### PR TITLE
 Test whether x86 afb+ updates size in fcn rbtree after adding bb

### DIFF
--- a/new/db/cmd/cmd_pd2
+++ b/new/db/cmd/cmd_pd2
@@ -57,105 +57,105 @@ EXPECT=<<RUN
 |       :   0x00560e67      push esi
 |      ,==< 0x00560e68      jmp 0x560e7d
 ..
-       `--> 0x00560e7d      pop esi
-        :   0x00560e7e      push eax
-        :   0x00560e7f      push edx
-       ,==< 0x00560e80      jmp 0x560e96
+|      `--> 0x00560e7d      pop esi
+|       :   0x00560e7e      push eax
+|       :   0x00560e7f      push edx
+|      ,==< 0x00560e80      jmp 0x560e96
 ..
-      |`--> 0x00560e96      rdtsc
-      | :   0x00560e98      jmp 0x560eb1
+|     |`--> 0x00560e96      rdtsc
+|     | :   0x00560e98      jmp 0x560eb1
 ..
-      ||:   0x00560eb1      pop edx
-      ||:   0x00560eb2      pop eax
-      ||:   0x00560eb3      pushfd
-      ||:   0x00560eb4      push eax
-      ||:   0x00560eb5      mov dword [esp], ecx
-      ||:   0x00560eb8      push ecx
-      ||:   0x00560eb9      mov dword [esp], 0x4b7dbaf4
-      ||:   0x00560ec0      mov dword [esp], ebx
-      ||:   0x00560ec3      mov ebx, 0x60
-      ||:   0x00560ec8      mov dword [esp + 4], ebx
-      ||:   0x00560ecc      pop ebx
-      ||:   0x00560ecd      push ecx
-      ||:   0x00560ece      mov dword [esp], 0x7fdd7312
-      ||:   0x00560ed5      or dword [esp], 0x76fe6216
-       |:   0x00560edc      shl dword [esp], 1
-       |:   0x00560ee0      or dword [esp], 0x5677e157
-       |:   0x00560ee7      sub dword [esp], 0x66a97007
-       |:   0x00560eee      add dword [esp], 0xd4a8fad4
-       |:   0x00560ef5      xchg dword [esp], ebp
-       |:   0x00560ef8      not ebp
-       |:   0x00560efa      xchg dword [esp], ebp
-       |:   0x00560efd      inc dword [esp]
-       |:   0x00560f00      sub dword [esp], 0x91ea8610
-       |:   0x00560f07      push ebp
-       |:   0x00560f08      mov ebp, esp
-       |:   0x00560f0a      add ebp, 4
-       |:   0x00560f10      sub ebp, 4
-       |:   0x00560f16      xchg dword [esp], ebp
-       |:   0x00560f19      pop esp
-       |:   0x00560f1a      mov dword [esp], ecx
-       |:   0x00560f1d      mov dword [esp], eax
-       |:   0x00560f20      push 0x5a9b4939
-       |:   0x00560f25      mov dword [esp], ecx
-       |:   0x00560f28      mov ecx, esp
-        :   0x00560f2a      push ebx
-        :   0x00560f2b      mov ebx, 4
-        :   0x00560f30      add ecx, ebx
-        :   0x00560f32      pop ebx
-        :   0x00560f33      sub ecx, 4
-        :   0x00560f36      xor ecx, dword [esp]
-        :   0x00560f39      xor dword [esp], ecx
-        :   0x00560f3c      xor ecx, dword [esp]
-        :   0x00560f3f      pop esp
-        :   0x00560f40      mov dword [esp], ebx
-        :   0x00560f43      push dword [esp + 0x10]
-        :   0x00560f47      mov eax, dword [esp]
-        :   0x00560f4a      push esi
-        :   0x00560f4b      mov esi, esp
-        :   0x00560f4d      push edx
-        :   0x00560f4e      mov edx, 0x75ff55bb
-        :   0x00560f53      and edx, 0x7e5d8b17
-        :   0x00560f59      xor edx, 0x745d0117
-        :   0x00560f5f      add esi, edx
-        :   0x00560f61      mov edx, dword [esp]
-        :   0x00560f64      add esp, 4
-        :   0x00560f67      add esi, 4
-        :   0x00560f6d      xchg dword [esp], esi
-        :   0x00560f70      pop esp
-        :   0x00560f71      push dword [esp + 8]
-        :   0x00560f75      push dword [esp]
-        :   0x00560f78      mov ebx, dword [esp]
-        :   0x00560f7b      push ebx
-        :   0x00560f7c      mov ebx, esp
-        :   0x00560f7e      add ebx, 4
-        :   0x00560f84      add ebx, 4
-        :   0x00560f8a      xchg dword [esp], ebx
-        :   0x00560f8d      pop esp
-        :   0x00560f8e      add esp, 4
-        :   0x00560f91      mov dword [esp + 8], eax
-        :   0x00560f95      mov dword [esp + 0x10], ebx
-        :   0x00560f99      push dword [esp]
-        :   0x00560f9c      pop ebx
-        :   0x00560f9d      push ebx
-        :   0x00560f9e      mov ebx, esp
-        :   0x00560fa0      add ebx, 4
-        :   0x00560fa6      add ebx, 4
-        :   0x00560fa9      push ebx
-        :   0x00560faa      push dword [esp + 4]
-        :   0x00560fae      pop ebx
-        :   0x00560faf      pop dword [esp]
-        :   0x00560fb2      mov esp, dword [esp]
-        :   0x00560fb5      mov eax, dword [esp]
-        :   0x00560fb8      push ebx
-        :   0x00560fb9      mov dword [esp], 0x1e8e43e4
-        :   0x00560fc0      mov dword [esp], eax
-        :   0x00560fc3      mov eax, esp
-        :   0x00560fc5      add eax, 4
-        :   0x00560fca      add eax, 4
-        :   0x00560fcf      xchg dword [esp], eax
-        :   0x00560fd2      mov esp, dword [esp]
-        `=< 0x00560fd5      jmp 0x43d3f7
+|     ||:   0x00560eb1      pop edx
+|     ||:   0x00560eb2      pop eax
+|     ||:   0x00560eb3      pushfd
+|     ||:   0x00560eb4      push eax
+|     ||:   0x00560eb5      mov dword [esp], ecx
+|     ||:   0x00560eb8      push ecx
+|     ||:   0x00560eb9      mov dword [esp], 0x4b7dbaf4
+|     ||:   0x00560ec0      mov dword [esp], ebx
+|     ||:   0x00560ec3      mov ebx, 0x60
+|     ||:   0x00560ec8      mov dword [var_4h], ebx
+|     ||:   0x00560ecc      pop ebx
+|     ||:   0x00560ecd      push ecx
+|     ||:   0x00560ece      mov dword [esp], 0x7fdd7312
+|     ||:   0x00560ed5      or dword [esp], 0x76fe6216
+|      |:   0x00560edc      shl dword [esp], 1
+|      |:   0x00560ee0      or dword [esp], 0x5677e157
+|      |:   0x00560ee7      sub dword [esp], 0x66a97007
+|      |:   0x00560eee      add dword [esp], 0xd4a8fad4
+|      |:   0x00560ef5      xchg dword [esp], ebp
+|      |:   0x00560ef8      not ebp
+|      |:   0x00560efa      xchg dword [esp], ebp
+|      |:   0x00560efd      inc dword [esp]
+|      |:   0x00560f00      sub dword [esp], 0x91ea8610
+|      |:   0x00560f07      push ebp
+|      |:   0x00560f08      mov ebp, esp
+|      |:   0x00560f0a      add ebp, 4
+|      |:   0x00560f10      sub ebp, 4
+|      |:   0x00560f16      xchg dword [esp], ebp
+|      |:   0x00560f19      pop esp
+|      |:   0x00560f1a      mov dword [esp], ecx
+|      |:   0x00560f1d      mov dword [esp], eax
+|      |:   0x00560f20      push 0x5a9b4939
+|      |:   0x00560f25      mov dword [esp], ecx
+|      |:   0x00560f28      mov ecx, esp
+|       :   0x00560f2a      push ebx
+|       :   0x00560f2b      mov ebx, 4
+|       :   0x00560f30      add ecx, ebx
+|       :   0x00560f32      pop ebx
+|       :   0x00560f33      sub ecx, 4
+|       :   0x00560f36      xor ecx, dword [esp]
+|       :   0x00560f39      xor dword [esp], ecx
+|       :   0x00560f3c      xor ecx, dword [esp]
+|       :   0x00560f3f      pop esp
+|       :   0x00560f40      mov dword [esp], ebx
+|       :   0x00560f43      push dword [var_10h]
+|       :   0x00560f47      mov eax, dword [esp]
+|       :   0x00560f4a      push esi
+|       :   0x00560f4b      mov esi, esp
+|       :   0x00560f4d      push edx
+|       :   0x00560f4e      mov edx, 0x75ff55bb
+|       :   0x00560f53      and edx, 0x7e5d8b17
+|       :   0x00560f59      xor edx, 0x745d0117
+|       :   0x00560f5f      add esi, edx
+|       :   0x00560f61      mov edx, dword [esp]
+|       :   0x00560f64      add esp, 4
+|       :   0x00560f67      add esi, 4
+|       :   0x00560f6d      xchg dword [esp], esi
+|       :   0x00560f70      pop esp
+|       :   0x00560f71      push dword [var_8h]
+|       :   0x00560f75      push dword [esp]
+|       :   0x00560f78      mov ebx, dword [esp]
+|       :   0x00560f7b      push ebx
+|       :   0x00560f7c      mov ebx, esp
+|       :   0x00560f7e      add ebx, 4
+|       :   0x00560f84      add ebx, 4
+|       :   0x00560f8a      xchg dword [esp], ebx
+|       :   0x00560f8d      pop esp
+|       :   0x00560f8e      add esp, 4
+|       :   0x00560f91      mov dword [var_8h], eax
+|       :   0x00560f95      mov dword [var_10h], ebx
+|       :   0x00560f99      push dword [esp]
+|       :   0x00560f9c      pop ebx
+|       :   0x00560f9d      push ebx
+|       :   0x00560f9e      mov ebx, esp
+|       :   0x00560fa0      add ebx, 4
+|       :   0x00560fa6      add ebx, 4
+|       :   0x00560fa9      push ebx
+|       :   0x00560faa      push dword [var_4h]
+|       :   0x00560fae      pop ebx
+|       :   0x00560faf      pop dword [esp]
+|       :   0x00560fb2      mov esp, dword [esp]
+|       :   0x00560fb5      mov eax, dword [esp]
+|       :   0x00560fb8      push ebx
+|       :   0x00560fb9      mov dword [esp], 0x1e8e43e4
+|       :   0x00560fc0      mov dword [esp], eax
+|       :   0x00560fc3      mov eax, esp
+|       :   0x00560fc5      add eax, 4
+|       :   0x00560fca      add eax, 4
+|       :   0x00560fcf      xchg dword [esp], eax
+|       :   0x00560fd2      mov esp, dword [esp]
+\       `=< 0x00560fd5      jmp 0x43d3f7
 RUN
 
 NAME=pdf hidden code in sparse fix
@@ -181,45 +181,45 @@ EXPECT=<<RUN
 |       :   0x00560e67      56             push esi
 |      ,==< 0x00560e68      e904000000     jmp 0x560e71
 ..
-       |:   ; CODE XREF from fcn.00560e67 (+0x1)
-       `--> 0x00560e71      90             nop
-        :   0x00560e72      eb09           jmp 0x560e7d
+|      |:   ; CODE XREF from fcn.00560e67 (0x560e68)
+|      `--> 0x00560e71      90             nop
+|       :   0x00560e72      eb09           jmp 0x560e7d
 ..
-        :   ; CODE XREF from fcn.00560e67 (+0xb)
-        :   0x00560e7d      5e             pop esi
-        :   0x00560e7e      50             push eax
-        :   0x00560e7f      52             push edx
-       ,==< 0x00560e80      e911000000     jmp 0x560e96
+|       :   ; CODE XREF from fcn.00560e67 (0x560e72)
+|       :   0x00560e7d      5e             pop esi
+|       :   0x00560e7e      50             push eax
+|       :   0x00560e7f      52             push edx
+|      ,==< 0x00560e80      e911000000     jmp 0x560e96
 ..
-      ||:   ; CODE XREF from fcn.00560e67 (+0x19)
-      |`--> 0x00560e96      0f31           rdtsc
-      | :   0x00560e98      e914000000     jmp 0x560eb1
+|     ||:   ; CODE XREF from fcn.00560e67 (0x560e80)
+|     |`--> 0x00560e96      0f31           rdtsc
+|     | :   0x00560e98      e914000000     jmp 0x560eb1
 ..
-      ||:   ; CODE XREF from fcn.00560e67 (+0x31)
-      ||:   0x00560eb1      5a             pop edx
-      ||`=< 0x00560eb2      e940c5edff     jmp 0x43d3f7
+|     ||:   ; CODE XREF from fcn.00560e67 (0x560e98)
+|     ||:   0x00560eb1      5a             pop edx
+\     ||`=< 0x00560eb2      e940c5edff     jmp 0x43d3f7
 
 / (fcn) fcn.00560e67 30
 | 0x00560e67      56             push esi
 | 0x00560e68      e904000000     jmp 0x560e71
 | ----------- true: 0x00560e71
-  ; CODE XREF from fcn.00560e67 (+0x1)
-  0x00560e71      90             nop
-  0x00560e72      eb09           jmp 0x560e7d
+| ; CODE XREF from fcn.00560e67 (0x560e68)
+| 0x00560e71      90             nop
+| 0x00560e72      eb09           jmp 0x560e7d
 | ----------- true: 0x00560e7d
-  ; CODE XREF from fcn.00560e67 (+0xb)
-  0x00560e7d      5e             pop esi
-  0x00560e7e      50             push eax
-  0x00560e7f      52             push edx
-  0x00560e80      e911000000     jmp 0x560e96
+| ; CODE XREF from fcn.00560e67 (0x560e72)
+| 0x00560e7d      5e             pop esi
+| 0x00560e7e      50             push eax
+| 0x00560e7f      52             push edx
+| 0x00560e80      e911000000     jmp 0x560e96
 | ----------- true: 0x00560e96
-  ; CODE XREF from fcn.00560e67 (+0x19)
-  0x00560e96      0f31           rdtsc
-  0x00560e98      e914000000     jmp 0x560eb1
+| ; CODE XREF from fcn.00560e67 (0x560e80)
+| 0x00560e96      0f31           rdtsc
+| 0x00560e98      e914000000     jmp 0x560eb1
 | ----------- true: 0x00560eb1
-  ; CODE XREF from fcn.00560e67 (+0x31)
-  0x00560eb1      5a             pop edx
-  0x00560eb2      e940c5edff     jmp 0x43d3f7
+| ; CODE XREF from fcn.00560e67 (0x560e98)
+| 0x00560eb1      5a             pop edx
+\ 0x00560eb2      e940c5edff     jmp 0x43d3f7
 
 RUN
 

--- a/new/db/cmd/cmd_pd2
+++ b/new/db/cmd/cmd_pd2
@@ -42,119 +42,120 @@ CMDS=<<EXPECT
 e asm.bytes=false
 e asm.comments=false
 s 0x560e67
-af
+af+ 0x00560e67 fcn.00560e67
+afb+ 0x00560e67 0x00560e67 6 0x00560e7d
+afb+ 0x00560e67 0x00560e7d 8 0x00560e96
+afb+ 0x00560e67 0x00560e96 7 0x00560eb1
+afb+ 0x00560e67 0x00560eb1 297
 pdf
 EXPECT=<<RUN
-/ (fcn) fcn.00560e67 6412
+/ (fcn) fcn.00560e67 318
 |   fcn.00560e67 ();
-|     ::    ; var int var_4h @ esp+0x4
-|     ::    ; var int var_8h @ esp+0x8
-|     ::    ; var int var_10h @ esp+0x10
-|     ::    ; var int var_24h @ esp+0x24
-|     ::    ; var int var_28h @ esp+0x28
-|     ::    0x00560e67      push esi
-|    ,====< 0x00560e68      jmp 0x560e7d
+|       :   ; var int var_4h @ esp+0x4
+|       :   ; var int var_8h @ esp+0x8
+|       :   ; var int var_10h @ esp+0x10
+|       :   0x00560e67      push esi
+|      ,==< 0x00560e68      jmp 0x560e7d
 ..
-|    `----> 0x00560e7d      pop esi
-|     ::    0x00560e7e      push eax
-|     ::    0x00560e7f      push edx
-|    ,====< 0x00560e80      jmp 0x560e96
+       `--> 0x00560e7d      pop esi
+        :   0x00560e7e      push eax
+        :   0x00560e7f      push edx
+       ,==< 0x00560e80      jmp 0x560e96
 ..
-|   |`----> 0x00560e96      rdtsc
-|   | ::    0x00560e98      jmp 0x560eb1
+      |`--> 0x00560e96      rdtsc
+      | :   0x00560e98      jmp 0x560eb1
 ..
-|   ||::    0x00560eb1      pop edx
-|   ||::    0x00560eb2      pop eax
-|   ||::    0x00560eb3      pushfd
-|   ||::    0x00560eb4      push eax
-|   ||::    0x00560eb5      mov dword [esp], ecx
-|   ||::    0x00560eb8      push ecx
-|   ||::    0x00560eb9      mov dword [esp], 0x4b7dbaf4
-|   ||::    0x00560ec0      mov dword [esp], ebx
-|   ||::    0x00560ec3      mov ebx, 0x60
-|   ||::    0x00560ec8      mov dword [var_4h], ebx
-|   ||::    0x00560ecc      pop ebx
-|   ||::    0x00560ecd      push ecx
-|   ||::    0x00560ece      mov dword [esp], 0x7fdd7312
-|   ||::    0x00560ed5      or dword [esp], 0x76fe6216
-|    |::    0x00560edc      shl dword [esp], 1
-|    |::    0x00560ee0      or dword [esp], 0x5677e157
-|    |::    0x00560ee7      sub dword [esp], 0x66a97007
-|    |::    0x00560eee      add dword [esp], 0xd4a8fad4
-|    |::    0x00560ef5      xchg dword [esp], ebp
-|    |::    0x00560ef8      not ebp
-|    |::    0x00560efa      xchg dword [esp], ebp
-|    |::    0x00560efd      inc dword [esp]
-|    |::    0x00560f00      sub dword [esp], 0x91ea8610
-|    |::    0x00560f07      push ebp
-|    |::    0x00560f08      mov ebp, esp
-|    |::    0x00560f0a      add ebp, 4
-|    |::    0x00560f10      sub ebp, 4
-|    |::    0x00560f16      xchg dword [esp], ebp
-|    |::    0x00560f19      pop esp
-|    |::    0x00560f1a      mov dword [esp], ecx
-|    |::    0x00560f1d      mov dword [esp], eax
-|    |::    0x00560f20      push 0x5a9b4939
-|    |::    0x00560f25      mov dword [esp], ecx
-|    |::    0x00560f28      mov ecx, esp
-|     ::    0x00560f2a      push ebx
-|     ::    0x00560f2b      mov ebx, 4
-|     ::    0x00560f30      add ecx, ebx
-|     ::    0x00560f32      pop ebx
-|     ::    0x00560f33      sub ecx, 4
-|     ::    0x00560f36      xor ecx, dword [esp]
-|     ::    0x00560f39      xor dword [esp], ecx
-|     ::    0x00560f3c      xor ecx, dword [esp]
-|     ::    0x00560f3f      pop esp
-|     ::    0x00560f40      mov dword [esp], ebx
-|     ::    0x00560f43      push dword [var_10h]
-|     ::    0x00560f47      mov eax, dword [esp]
-|     ::    0x00560f4a      push esi
-|     ::    0x00560f4b      mov esi, esp
-|     ::    0x00560f4d      push edx
-|     ::    0x00560f4e      mov edx, 0x75ff55bb
-|     ::    0x00560f53      and edx, 0x7e5d8b17
-|     ::    0x00560f59      xor edx, 0x745d0117
-|     ::    0x00560f5f      add esi, edx
-|     ::    0x00560f61      mov edx, dword [esp]
-|     ::    0x00560f64      add esp, 4
-|     ::    0x00560f67      add esi, 4
-|     ::    0x00560f6d      xchg dword [esp], esi
-|     ::    0x00560f70      pop esp
-|     ::    0x00560f71      push dword [var_8h]
-|     ::    0x00560f75      push dword [esp]
-|     ::    0x00560f78      mov ebx, dword [esp]
-|     ::    0x00560f7b      push ebx
-|     ::    0x00560f7c      mov ebx, esp
-|     ::    0x00560f7e      add ebx, 4
-|     ::    0x00560f84      add ebx, 4
-|     ::    0x00560f8a      xchg dword [esp], ebx
-|     ::    0x00560f8d      pop esp
-|     ::    0x00560f8e      add esp, 4
-|     ::    0x00560f91      mov dword [var_8h], eax
-|     ::    0x00560f95      mov dword [var_10h], ebx
-|     ::    0x00560f99      push dword [esp]
-|     ::    0x00560f9c      pop ebx
-|     ::    0x00560f9d      push ebx
-|     ::    0x00560f9e      mov ebx, esp
-|     ::    0x00560fa0      add ebx, 4
-|     ::    0x00560fa6      add ebx, 4
-|     ::    0x00560fa9      push ebx
-|     ::    0x00560faa      push dword [var_4h]
-|     ::    0x00560fae      pop ebx
-|     ::    0x00560faf      pop dword [esp]
-|     ::    0x00560fb2      mov esp, dword [esp]
-|     ::    0x00560fb5      mov eax, dword [esp]
-|     ::    0x00560fb8      push ebx
-|     ::    0x00560fb9      mov dword [esp], 0x1e8e43e4
-|     ::    0x00560fc0      mov dword [esp], eax
-|     ::    0x00560fc3      mov eax, esp
-|     ::    0x00560fc5      add eax, 4
-|     ::    0x00560fca      add eax, 4
-|     ::    0x00560fcf      xchg dword [esp], eax
-|     ::    0x00560fd2      mov esp, dword [esp]
-\     :`==< 0x00560fd5      jmp 0x43d3f7
-..
+      ||:   0x00560eb1      pop edx
+      ||:   0x00560eb2      pop eax
+      ||:   0x00560eb3      pushfd
+      ||:   0x00560eb4      push eax
+      ||:   0x00560eb5      mov dword [esp], ecx
+      ||:   0x00560eb8      push ecx
+      ||:   0x00560eb9      mov dword [esp], 0x4b7dbaf4
+      ||:   0x00560ec0      mov dword [esp], ebx
+      ||:   0x00560ec3      mov ebx, 0x60
+      ||:   0x00560ec8      mov dword [esp + 4], ebx
+      ||:   0x00560ecc      pop ebx
+      ||:   0x00560ecd      push ecx
+      ||:   0x00560ece      mov dword [esp], 0x7fdd7312
+      ||:   0x00560ed5      or dword [esp], 0x76fe6216
+       |:   0x00560edc      shl dword [esp], 1
+       |:   0x00560ee0      or dword [esp], 0x5677e157
+       |:   0x00560ee7      sub dword [esp], 0x66a97007
+       |:   0x00560eee      add dword [esp], 0xd4a8fad4
+       |:   0x00560ef5      xchg dword [esp], ebp
+       |:   0x00560ef8      not ebp
+       |:   0x00560efa      xchg dword [esp], ebp
+       |:   0x00560efd      inc dword [esp]
+       |:   0x00560f00      sub dword [esp], 0x91ea8610
+       |:   0x00560f07      push ebp
+       |:   0x00560f08      mov ebp, esp
+       |:   0x00560f0a      add ebp, 4
+       |:   0x00560f10      sub ebp, 4
+       |:   0x00560f16      xchg dword [esp], ebp
+       |:   0x00560f19      pop esp
+       |:   0x00560f1a      mov dword [esp], ecx
+       |:   0x00560f1d      mov dword [esp], eax
+       |:   0x00560f20      push 0x5a9b4939
+       |:   0x00560f25      mov dword [esp], ecx
+       |:   0x00560f28      mov ecx, esp
+        :   0x00560f2a      push ebx
+        :   0x00560f2b      mov ebx, 4
+        :   0x00560f30      add ecx, ebx
+        :   0x00560f32      pop ebx
+        :   0x00560f33      sub ecx, 4
+        :   0x00560f36      xor ecx, dword [esp]
+        :   0x00560f39      xor dword [esp], ecx
+        :   0x00560f3c      xor ecx, dword [esp]
+        :   0x00560f3f      pop esp
+        :   0x00560f40      mov dword [esp], ebx
+        :   0x00560f43      push dword [esp + 0x10]
+        :   0x00560f47      mov eax, dword [esp]
+        :   0x00560f4a      push esi
+        :   0x00560f4b      mov esi, esp
+        :   0x00560f4d      push edx
+        :   0x00560f4e      mov edx, 0x75ff55bb
+        :   0x00560f53      and edx, 0x7e5d8b17
+        :   0x00560f59      xor edx, 0x745d0117
+        :   0x00560f5f      add esi, edx
+        :   0x00560f61      mov edx, dword [esp]
+        :   0x00560f64      add esp, 4
+        :   0x00560f67      add esi, 4
+        :   0x00560f6d      xchg dword [esp], esi
+        :   0x00560f70      pop esp
+        :   0x00560f71      push dword [esp + 8]
+        :   0x00560f75      push dword [esp]
+        :   0x00560f78      mov ebx, dword [esp]
+        :   0x00560f7b      push ebx
+        :   0x00560f7c      mov ebx, esp
+        :   0x00560f7e      add ebx, 4
+        :   0x00560f84      add ebx, 4
+        :   0x00560f8a      xchg dword [esp], ebx
+        :   0x00560f8d      pop esp
+        :   0x00560f8e      add esp, 4
+        :   0x00560f91      mov dword [esp + 8], eax
+        :   0x00560f95      mov dword [esp + 0x10], ebx
+        :   0x00560f99      push dword [esp]
+        :   0x00560f9c      pop ebx
+        :   0x00560f9d      push ebx
+        :   0x00560f9e      mov ebx, esp
+        :   0x00560fa0      add ebx, 4
+        :   0x00560fa6      add ebx, 4
+        :   0x00560fa9      push ebx
+        :   0x00560faa      push dword [esp + 4]
+        :   0x00560fae      pop ebx
+        :   0x00560faf      pop dword [esp]
+        :   0x00560fb2      mov esp, dword [esp]
+        :   0x00560fb5      mov eax, dword [esp]
+        :   0x00560fb8      push ebx
+        :   0x00560fb9      mov dword [esp], 0x1e8e43e4
+        :   0x00560fc0      mov dword [esp], eax
+        :   0x00560fc3      mov eax, esp
+        :   0x00560fc5      add eax, 4
+        :   0x00560fca      add eax, 4
+        :   0x00560fcf      xchg dword [esp], eax
+        :   0x00560fd2      mov esp, dword [esp]
+        `=< 0x00560fd5      jmp 0x43d3f7
 RUN
 
 NAME=pdf hidden code in sparse fix
@@ -166,56 +167,60 @@ wx 90eb09 @ 0x560e71
 wx e904000000 @ 0x560e68
 wx e940c5edff @ 0x560eb2
 s 0x560e67
-af
+af+ 0x00560e67 fcn.00560e67
+afb+ 0x00560e67 0x00560e67 6 0x00560e71
+afb+ 0x00560e67 0x00560e71 3 0x00560e7d
+afb+ 0x00560e67 0x00560e7d 8 0x00560e96
+afb+ 0x00560e67 0x00560e96 7 0x00560eb1
+afb+ 0x00560e67 0x00560eb1 6
 pdf
 ?e
 pdr.
 EXPECT=<<RUN
-/ (fcn) fcn.00560e67 6124
-|    :::    0x00560e67      56             push esi
-|   ,=====< 0x00560e68      e904000000     jmp 0x560e71
+/ (fcn) fcn.00560e67 30
+|       :   0x00560e67      56             push esi
+|      ,==< 0x00560e68      e904000000     jmp 0x560e71
 ..
-|   |:::    ; CODE XREF from fcn.00560e67 (0x560e68)
-|   `-----> 0x00560e71      90             nop
-|    :::    0x00560e72      eb09           jmp 0x560e7d
+       |:   ; CODE XREF from fcn.00560e67 (+0x1)
+       `--> 0x00560e71      90             nop
+        :   0x00560e72      eb09           jmp 0x560e7d
 ..
-|    :::    ; CODE XREF from fcn.00560e67 (0x560e72)
-|    :::    0x00560e7d      5e             pop esi
-|    :::    0x00560e7e      50             push eax
-|    :::    0x00560e7f      52             push edx
-|   ,=====< 0x00560e80      e911000000     jmp 0x560e96
+        :   ; CODE XREF from fcn.00560e67 (+0xb)
+        :   0x00560e7d      5e             pop esi
+        :   0x00560e7e      50             push eax
+        :   0x00560e7f      52             push edx
+       ,==< 0x00560e80      e911000000     jmp 0x560e96
 ..
-|  ||:::    ; CODE XREF from fcn.00560e67 (0x560e80)
-|  |`-----> 0x00560e96      0f31           rdtsc
-|  | :::    0x00560e98      e914000000     jmp 0x560eb1
+      ||:   ; CODE XREF from fcn.00560e67 (+0x19)
+      |`--> 0x00560e96      0f31           rdtsc
+      | :   0x00560e98      e914000000     jmp 0x560eb1
 ..
-|  ||:::    ; CODE XREF from fcn.00560e67 (0x560e98)
-|  ||:::    0x00560eb1      5a             pop edx
-\  ||:`===< 0x00560eb2      e940c5edff     jmp 0x43d3f7
-..
+      ||:   ; CODE XREF from fcn.00560e67 (+0x31)
+      ||:   0x00560eb1      5a             pop edx
+      ||`=< 0x00560eb2      e940c5edff     jmp 0x43d3f7
 
-/ (fcn) fcn.00560e67 6124
+/ (fcn) fcn.00560e67 30
 | 0x00560e67      56             push esi
 | 0x00560e68      e904000000     jmp 0x560e71
 | ----------- true: 0x00560e71
-| ; CODE XREF from fcn.00560e67 (0x560e68)
-| 0x00560e71      90             nop
-| 0x00560e72      eb09           jmp 0x560e7d
+  ; CODE XREF from fcn.00560e67 (+0x1)
+  0x00560e71      90             nop
+  0x00560e72      eb09           jmp 0x560e7d
 | ----------- true: 0x00560e7d
-| ; CODE XREF from fcn.00560e67 (0x560e72)
-| 0x00560e7d      5e             pop esi
-| 0x00560e7e      50             push eax
-| 0x00560e7f      52             push edx
-| 0x00560e80      e911000000     jmp 0x560e96
+  ; CODE XREF from fcn.00560e67 (+0xb)
+  0x00560e7d      5e             pop esi
+  0x00560e7e      50             push eax
+  0x00560e7f      52             push edx
+  0x00560e80      e911000000     jmp 0x560e96
 | ----------- true: 0x00560e96
-| ; CODE XREF from fcn.00560e67 (0x560e80)
-| 0x00560e96      0f31           rdtsc
-| 0x00560e98      e914000000     jmp 0x560eb1
+  ; CODE XREF from fcn.00560e67 (+0x19)
+  0x00560e96      0f31           rdtsc
+  0x00560e98      e914000000     jmp 0x560eb1
 | ----------- true: 0x00560eb1
-| ; CODE XREF from fcn.00560e67 (0x560e98)
-| 0x00560eb1      5a             pop edx
-\ 0x00560eb2      e940c5edff     jmp 0x43d3f7
-| ----------- true: 0x0043d3f7
+  ; CODE XREF from fcn.00560e67 (+0x31)
+  0x00560eb1      5a             pop edx
+  0x00560eb2      e940c5edff     jmp 0x43d3f7
+
 RUN
 
 NAME=esil func cmts


### PR DESCRIPTION
Modified tests for radare/radare2#13214 and radare/radare2#13193.