### PR TITLE
Fix test due to usage of r_str_escape_utf8_for_json() for pfj z

### DIFF
--- a/new/db/cmd/cmd_pf_elf
+++ b/new/db/cmd/cmd_pf_elf
@@ -239,7 +239,7 @@ EXPECT=<<RUN
         "name": "magic",
         "type": "z",
         "offset": 0,
-        "value": ".ELF..."
+        "value": "\u007fELF\u0001\u0001\u0001"
       },
       {
         "name": "class",


### PR DESCRIPTION
Fixed test due to radare/radare2#13734.