### PR TITLE
 Test whether extra stderr blank line is prevented when using @@= with `prz`

### DIFF
--- a/new/db/cmd/feat_foreach
+++ b/new/db/cmd/feat_foreach
@@ -55,7 +55,6 @@ wz 1 2 3 4
 pd 1 @@= `prz`
 EXPECT=<<RUN
             0x00000001      2032           and byte [rdx], dh
-
             0x00000002      3220           xor ah, byte [rax]
             0x00000003      2033           and byte [rbx], dh
             0x00000004      3320           xor esp, dword [rax]

--- a/new/db/cmd/feat_foreach
+++ b/new/db/cmd/feat_foreach
@@ -46,3 +46,17 @@ CMDS=<<EOF
 ?v $$ @@= 10   20   30
 EOF
 RUN
+
+NAME=@@= `prz` fix
+FILE=-
+ONE_STREAM=true
+CMDS=<<EXPECT
+wz 1 2 3 4
+pd 1 @@= `prz`
+EXPECT=<<RUN
+            0x00000001      2032           and byte [rdx], dh
+
+            0x00000002      3220           xor ah, byte [rax]
+            0x00000003      2033           and byte [rbx], dh
+            0x00000004      3320           xor esp, dword [rax]
+RUN


### PR DESCRIPTION
Added test for radare/radare2#13935.