### PR TITLE
Fix tests due to using op->disp instead of op->ptr for disp of x86 CMP (and ACMP)

### DIFF
--- a/new/db/cmd/cmd_pd2
+++ b/new/db/cmd/cmd_pd2
@@ -555,6 +555,10 @@ e io.cache=true
 "wa mov rdx, [rip + 0x17792]; mov rsi, [rip + 0x1d84b]" @ 0x000041e7
 "wa mov rdi, [rip + 0x147f6]" @ 0x00004225
 .(insn_tests)
+?e
+wx 483b1592770100483b354bd80100 @ 0x000041e7  # cmp rdx, [rip + 0x17792]; cmp rsi, [rip + 0x1d84b]
+wx 483b3df6470100 @ 0x00004225  # cmp rdi, [rip + 0x147f6]
+.(insn_tests)
 EXPECT=<<RUN
         ,=< 0x000041e0      je 0x421a
         |   0x000041e2      mov ecx, 4
@@ -638,6 +642,48 @@ EXPECT=<<RUN
 
             [32m0x000041ee[0m      [37mmov[36m rax[0m,[36m qword [0m[[36mrip [0m+[36m[36m [33m0x1d84b[0m][36m[0m[0m[31m             ; [[31m0x21a40[31m:8]=0x18d31 str.literal[0m
             [32m0x00004225[0m      [37mmov[36m rax[0m,[36m qword [0m[[36mrip [0m+[36m[36m [33m0x147f6[0m][36m[0m[0m[31m             ; str.COLUMNS
+            [31m                                                           ; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m ; "COLUMNS"[0m
+
+        ,=< 0x000041e0      je 0x421a
+        |   0x000041e2      mov ecx, 4
+        |   0x000041e7      cmp rdx, qword [0x0001b980]                ; [0x1b980:8]=0x100000000
+        |   0x000041ee      cmp rsi, qword [0x00021a40]                ; [0x21a40:8]=0x18d31 str.literal
+        |   0x000041f5      mov rdi, rax
+        |   0x000041f8      call 0xc660
+        |   0x000041fe      test eax, eax
+       ,==< 0x00004200      js 0x4ae5
+       ||   0x00004206      cdqe
+       ||   0x00004208      lea rdx, [0x0001b980]
+       ||   0x0000420f      xor edi, edi
+       ||   0x00004211      mov esi, dword [rdx + rax*4]
+       ||   0x00004214      call 0x13c50
+       |`-> 0x0000421a      mov qword [0x000232b0], 0x50               ; 'P'
+       |                                                               ; [0x232b0:8]=0
+       |    0x00004225      cmp rdi, qword [str.COLUMNS]               ; [0x18a22:8]=0x534e4d554c4f43 ; "COLUMNS"
+
+            0x000041ee      cmp rsi, qword [rip + 0x1d84b]             ; [0x21a40:8]=0x18d31 str.literal
+            0x00004225      cmp rdi, qword [rip + 0x147f6]             ; str.COLUMNS
+                                                                       ; [0x18a22:8]=0x534e4d554c4f43 ; "COLUMNS"
+
+        [36m,[0m[36m=[0m[36m<[0m [32m0x000041e0[0m      [32mje 0x421a[0m[0m
+        [36m|[0m   [32m0x000041e2[0m      [37mmov[36m ecx[0m,[36m[36m [33m4[0m[0m[0m
+        [36m|[0m   [32m0x000041e7[0m      [36mcmp[36m rdx[0m,[36m qword[36m [0m[[36m[33m0x0001b980[0m][36m[0m[0m[31m                ; [[31m0x1b980[31m:8]=0x100000000[0m
+        [36m|[0m   [32m0x000041ee[0m      [36mcmp[36m rsi[0m,[36m qword[36m [0m[[36m[33m0x00021a40[0m][36m[0m[0m[31m                ; [[31m0x21a40[31m:8]=0x18d31 str.literal[0m
+        [36m|[0m   [32m0x000041f5[0m      [37mmov[36m rdi[0m,[36m[36m rax[0m[0m[0m
+        [36m|[0m   [32m0x000041f8[0m      [1;92mcall 0xc660[0m[0m
+        [36m|[0m   [32m0x000041fe[0m      [36mtest[36m eax[0m,[36m[36m eax[0m[0m[0m
+       [36m,[0m[36m=[0m[36m=[0m[36m<[0m [32m0x00004200[0m      [32mjs 0x4ae5[0m[0m
+       [36m|[0m[36m|[0m   [32m0x00004206[0m      [37mcdqe[0m[0m[0m
+       [36m|[0m[36m|[0m   [32m0x00004208[0m      [37mlea[36m rdx[0m,[36m[36m [0m[[36m[33m0x0001b980[0m][36m[0m[0m[0m
+       [36m|[0m[36m|[0m   [32m0x0000420f[0m      [36mxor[36m edi[0m,[36m[36m edi[0m[0m[0m
+       [36m|[0m[36m|[0m   [32m0x00004211[0m      [37mmov[36m esi[0m,[36m dword [0m[[36mrdx [0m+[36m[36m rax[0m*[33m4[0m][36m[0m[0m[0m
+       [36m|[0m[36m|[0m   [32m0x00004214[0m      [1;92mcall 0x13c50[0m[0m
+       [36m|[0m[36m`[0m[36m-[0m[36m>[0m [32m0x0000421a[0m      [37mmov qword[36m [0m[[36m[33m0x000232b0[0m][36m[0m,[36m[36m [33m0x50[0m[0m[31m               ; 'P'
+       [36m|[0m    [31m                                                           ; [0x232b0:8]=0[0m
+       [36m|[0m    [32m0x00004225[0m      [36mcmp[36m rdi[0m,[36m qword[36m [0m[[36m[36mstr.COLUMNS[0m][36m[0m[0m[31m               ; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m ; "COLUMNS"[0m
+
+            [32m0x000041ee[0m      [36mcmp[36m rsi[0m,[36m qword [0m[[36mrip [0m+[36m[36m [33m0x1d84b[0m][36m[0m[0m[31m             ; [[31m0x21a40[31m:8]=0x18d31 str.literal[0m
+            [32m0x00004225[0m      [36mcmp[36m rdi[0m,[36m qword [0m[[36mrip [0m+[36m[36m [33m0x147f6[0m][36m[0m[0m[31m             ; str.COLUMNS
             [31m                                                           ; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m ; "COLUMNS"[0m
 RUN
 

--- a/new/db/cmd/types
+++ b/new/db/cmd/types
@@ -640,7 +640,7 @@ EXPECT=<<EOF
             0x00000000      8b4004         mov eax, dword [eax + foo.b]
             0x00000003      895104         mov dword [ecx + foo.b], edx
             0x00000006      8d5008         lea edx, [eax + foo.c]
-            0x00000009      83780800       cmp dword [eax + foo.c], 0  ; [0x8:4]=0x8788308
+            0x00000009      83780800       cmp dword [eax + foo.c], 0
 EOF
 RUN
 


### PR DESCRIPTION
Added/fixed tests for radare/radare2#14868.